### PR TITLE
[codex] Add expired subscription email

### DIFF
--- a/app/commands/cmd/subscriptions/expire_overdue_subscriptions.rb
+++ b/app/commands/cmd/subscriptions/expire_overdue_subscriptions.rb
@@ -15,10 +15,20 @@ module Cmd
           @subscription.transaction do
             @subscription.expire!
           end
+          notify_expiration
           Result.new(true, @subscription, nil)
         rescue StandardError => e
           Result.new(false, @subscription, e.message)
         end
+      end
+
+      private
+
+      def notify_expiration
+        return if @subscription.expired_notification_sent_at.present?
+
+        ::Subscriptions::ExpirationMailer.with(subscription: @subscription).expired_email.deliver_later
+        @subscription.update!(expired_notification_sent_at: Time.current)
       end
     end
   end

--- a/app/jobs/subscriptions/expire_overdue_subscriptions_job.rb
+++ b/app/jobs/subscriptions/expire_overdue_subscriptions_job.rb
@@ -8,9 +8,9 @@ class Subscriptions::ExpireOverdueSubscriptionsJob
 
     if subscription_ids.any?
       expire_subscriptions(subscription_ids)
-      Rails.logger.info "[Subscriptions::ExpireOverdueSubscriptionsJob] #{subscription_ids.size} assinatura(s) processada(s) para expiracao."
+      Rails.logger.info "[Subscriptions::ExpireOverdueSubscriptionsJob] #{subscription_ids.size} assinatura(s) processada(s) para expiração."
     else
-      Rails.logger.info "[Subscriptions::ExpireOverdueSubscriptionsJob] Nenhuma assinatura vencida ha 10 dias ou mais para expirar."
+      Rails.logger.info "[Subscriptions::ExpireOverdueSubscriptionsJob] Nenhuma assinatura vencida há 10 dias ou mais para expirar."
     end
   end
 

--- a/app/jobs/subscriptions/notify_overdue_subscriptions_job.rb
+++ b/app/jobs/subscriptions/notify_overdue_subscriptions_job.rb
@@ -19,7 +19,7 @@ class Subscriptions::NotifyOverdueSubscriptionsJob
       result = Cmd::Subscriptions::NotifySubscription.new(subscription_id: id).call
 
       if result.success?
-        Rails.logger.info "[Subscriptions::NotifyOverdueSubscriptionsJob] Notificacao de vencimento registrada para assinatura ID #{id}."
+        Rails.logger.info "[Subscriptions::NotifyOverdueSubscriptionsJob] Notificação de vencimento registrada para assinatura ID #{id}."
       else
         Rails.logger.error "[Subscriptions::NotifyOverdueSubscriptionsJob] Erro ao notificar assinatura ID #{id}: #{result.errors}"
       end

--- a/app/mailers/subscriptions/expiration_mailer.rb
+++ b/app/mailers/subscriptions/expiration_mailer.rb
@@ -1,0 +1,20 @@
+class Subscriptions::ExpirationMailer < ApplicationMailer
+  def expired_email
+    @subscription = params[:subscription]
+    @company = @subscription.company
+    @plan = @subscription.plan
+    @responsible_name = @company.responsible&.name.presence || @company.name
+    @expired_on = @subscription.expired_date || Time.current
+
+    mail(
+      to: recipient_email,
+      subject: "Assinatura expirada - #{@company.name}"
+    )
+  end
+
+  private
+
+  def recipient_email
+    @company.responsible&.email.presence || @company.email
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -74,7 +74,8 @@ class Subscription < ApplicationRecord
             cancel_effective_on: nil,
             cancel_reason: nil,
             expired_date: nil,
-            expiration_warning_sent_at: nil)
+            expiration_warning_sent_at: nil,
+            expired_notification_sent_at: nil)
   end
 
   def cancel!

--- a/app/services/mercado_pago/webhook_processor.rb
+++ b/app/services/mercado_pago/webhook_processor.rb
@@ -144,7 +144,8 @@ module MercadoPago
         end_date: period_end.to_date,
         canceled_date: nil,
         expired_date: nil,
-        expiration_warning_sent_at: nil
+        expiration_warning_sent_at: nil,
+        expired_notification_sent_at: nil
       )
 
       Result.new(true, "Authorized payment #{authorized_payment_id} processado com sucesso")

--- a/app/views/subscriptions/cancellation_mailer/cancelled_email.html.erb
+++ b/app/views/subscriptions/cancellation_mailer/cancelled_email.html.erb
@@ -9,4 +9,4 @@
   <p>Plano cancelado: <strong><%= @plan.name %></strong>.</p>
 <% end %>
 
-<p>Se precisar, acesse Configuracoes > Assinatura para revisar os dados.</p>
+<p>Se precisar, acesse Configurações > Assinatura para revisar os dados.</p>

--- a/app/views/subscriptions/cancellation_mailer/cancelled_email.text.erb
+++ b/app/views/subscriptions/cancellation_mailer/cancelled_email.text.erb
@@ -6,4 +6,4 @@ A assinatura da empresa <%= @company.name %> foi cancelada com sucesso em <%= l(
 Plano cancelado: <%= @plan.name %>.
 
 <% end %>
-Se precisar, acesse Configuracoes > Assinatura para revisar os dados.
+Se precisar, acesse Configurações > Assinatura para revisar os dados.

--- a/app/views/subscriptions/expiration_mailer/expired_email.html.erb
+++ b/app/views/subscriptions/expiration_mailer/expired_email.html.erb
@@ -1,0 +1,16 @@
+<p>Olá, <%= @responsible_name %>.</p>
+
+<p>
+  A assinatura da empresa <strong><%= @company.name %></strong> foi expirada em
+  <strong><%= l(@expired_on, format: :short) %></strong>.
+</p>
+
+<p>
+  O acesso ao CatalystOps ficará indisponível até a regularização da assinatura.
+</p>
+
+<% if @plan.present? %>
+  <p>Plano expirado: <strong><%= @plan.name %></strong>.</p>
+<% end %>
+
+<p>Se precisar de ajuda para regularizar o acesso, responda este email ou entre em contato com nosso suporte.</p>

--- a/app/views/subscriptions/expiration_mailer/expired_email.text.erb
+++ b/app/views/subscriptions/expiration_mailer/expired_email.text.erb
@@ -1,0 +1,11 @@
+Olá, <%= @responsible_name %>.
+
+A assinatura da empresa <%= @company.name %> foi expirada em <%= l(@expired_on, format: :short) %>.
+
+O acesso ao CatalystOps ficará indisponível até a regularização da assinatura.
+
+<% if @plan.present? %>
+Plano expirado: <%= @plan.name %>.
+
+<% end %>
+Se precisar de ajuda para regularizar o acesso, responda este email ou entre em contato com nosso suporte.

--- a/app/views/subscriptions/expiration_warning_mailer/warning_email.html.erb
+++ b/app/views/subscriptions/expiration_warning_mailer/warning_email.html.erb
@@ -1,4 +1,4 @@
-<p>Ola, <%= @company.name %>.</p>
+<p>Olá, <%= @company.name %>.</p>
 
 <p>
   Identificamos que a assinatura do CatalystOps venceu em

--- a/app/views/subscriptions/expiration_warning_mailer/warning_email.text.erb
+++ b/app/views/subscriptions/expiration_warning_mailer/warning_email.text.erb
@@ -1,4 +1,4 @@
-Ola, <%= @company.name %>.
+Olá, <%= @company.name %>.
 
 Identificamos que a assinatura do CatalystOps venceu em <%= l(@expired_on) %>.
 

--- a/db/migrate/20260623120000_add_expired_notification_sent_at_to_subscriptions.rb
+++ b/db/migrate/20260623120000_add_expired_notification_sent_at_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddExpiredNotificationSentAtToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriptions, :expired_notification_sent_at, :datetime
+    add_index :subscriptions, :expired_notification_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_16_103000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -412,11 +412,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_16_103000) do
     t.datetime "cancel_requested_at"
     t.date "cancel_effective_on"
     t.string "cancel_reason"
+    t.datetime "expired_notification_sent_at"
     t.index ["cancel_at_period_end"], name: "index_subscriptions_on_cancel_at_period_end"
     t.index ["cancel_effective_on"], name: "index_subscriptions_on_cancel_effective_on"
     t.index ["company_id", "status"], name: "index_subscriptions_on_company_id_and_status"
     t.index ["company_id"], name: "index_subscriptions_on_company_id"
     t.index ["expiration_warning_sent_at"], name: "index_subscriptions_on_expiration_warning_sent_at"
+    t.index ["expired_notification_sent_at"], name: "index_subscriptions_on_expired_notification_sent_at"
     t.index ["external_payment_id"], name: "index_subscriptions_on_external_payment_id"
     t.index ["external_reference"], name: "index_subscriptions_on_external_reference"
     t.index ["external_subscription_id"], name: "index_subscriptions_on_external_subscription_id"

--- a/spec/commands/cmd/subscriptions/expire_overdue_subscriptions_spec.rb
+++ b/spec/commands/cmd/subscriptions/expire_overdue_subscriptions_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Cmd::Subscriptions::ExpireOverdueSubscriptions do
 
     it "expira assinatura com sucesso" do
       subscription = create(:subscription, status: :active)
+      mail_delivery = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+
+      allow(Subscriptions::ExpirationMailer).to receive(:with).with(subscription: subscription).and_return(double(expired_email: mail_delivery))
 
       result = described_class.new(subscription_id: subscription.id).call
 
@@ -22,17 +25,36 @@ RSpec.describe Cmd::Subscriptions::ExpireOverdueSubscriptions do
         expect(result.subscription).to eq(subscription)
         expect(subscription.reload).to be_expired
         expect(subscription.expired_date).to be_present
+        expect(subscription.expired_notification_sent_at).to be_present
+        expect(mail_delivery).to have_received(:deliver_later)
       end
     end
 
     it "retorna sucesso quando assinatura já está expirada" do
       subscription = create(:subscription, status: :expired, expired_date: Time.current)
 
+      allow(Subscriptions::ExpirationMailer).to receive(:with)
+
       result = described_class.new(subscription_id: subscription.id).call
 
       aggregate_failures do
         expect(result).to be_success
         expect(result.subscription).to eq(subscription)
+        expect(Subscriptions::ExpirationMailer).not_to have_received(:with)
+      end
+    end
+
+    it "não reenvia email quando a notificação de expiração já foi registrada" do
+      subscription = create(:subscription, status: :active, expired_notification_sent_at: 1.day.ago)
+
+      allow(Subscriptions::ExpirationMailer).to receive(:with)
+
+      result = described_class.new(subscription_id: subscription.id).call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(subscription.reload).to be_expired
+        expect(Subscriptions::ExpirationMailer).not_to have_received(:with)
       end
     end
 

--- a/spec/jobs/subscriptions/expire_overdue_subscriptions_job_spec.rb
+++ b/spec/jobs/subscriptions/expire_overdue_subscriptions_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Subscriptions::ExpireOverdueSubscriptionsJob, type: :job do
       aggregate_failures do
         expect(command).to have_received(:call)
         expect(Rails.logger).to have_received(:info).with("[Subscriptions::ExpireOverdueSubscriptionsJob] Assinatura ID #{subscription.id} expirada com sucesso.")
-        expect(Rails.logger).to have_received(:info).with("[Subscriptions::ExpireOverdueSubscriptionsJob] 1 assinatura(s) processada(s) para expiracao.")
+        expect(Rails.logger).to have_received(:info).with("[Subscriptions::ExpireOverdueSubscriptionsJob] 1 assinatura(s) processada(s) para expiração.")
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Subscriptions::ExpireOverdueSubscriptionsJob, type: :job do
 
       described_class.new.perform
 
-      expect(Rails.logger).to have_received(:info).with("[Subscriptions::ExpireOverdueSubscriptionsJob] Nenhuma assinatura vencida ha 10 dias ou mais para expirar.")
+      expect(Rails.logger).to have_received(:info).with("[Subscriptions::ExpireOverdueSubscriptionsJob] Nenhuma assinatura vencida há 10 dias ou mais para expirar.")
     end
 
     it "registra erro quando o command retorna falha" do

--- a/spec/jobs/subscriptions/notify_overdue_subscriptions_job_spec.rb
+++ b/spec/jobs/subscriptions/notify_overdue_subscriptions_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Subscriptions::NotifyOverdueSubscriptionsJob, type: :job do
       described_class.new.perform
 
       expect(command).to have_received(:call)
-      expect(Rails.logger).to have_received(:info).with("[Subscriptions::NotifyOverdueSubscriptionsJob] Notificacao de vencimento registrada para assinatura ID #{subscription.id}.")
+      expect(Rails.logger).to have_received(:info).with("[Subscriptions::NotifyOverdueSubscriptionsJob] Notificação de vencimento registrada para assinatura ID #{subscription.id}.")
     end
 
     it "registra erro sem interromper quando comando falha" do

--- a/spec/mailers/subscriptions/expiration_mailer_spec.rb
+++ b/spec/mailers/subscriptions/expiration_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Subscriptions::ExpirationMailer, type: :mailer do
+  describe "#expired_email" do
+    it "envia aviso de expiração para responsável" do
+      plan = create(:plan, name: "Plano Pro")
+      responsible = create(:user, :gestor, email: "responsavel@example.com")
+      company = create(:company, name: "Empresa Teste", plan: plan, responsible: responsible)
+      responsible.update!(company: company)
+      subscription = create(:subscription, company: company, subscription_plan: plan, status: :expired, expired_date: Date.current)
+
+      email = described_class.with(subscription: subscription).expired_email
+
+      expect(email.to).to eq(["responsavel@example.com"])
+      expect(email.subject).to eq("Assinatura expirada - Empresa Teste")
+      expect(email.body.encoded).to include("Empresa Teste")
+      expect(email.body.encoded).to include("Plano Pro")
+      expect(email.body.encoded).to include("regulariza")
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -209,7 +209,8 @@ RSpec.describe Subscription, type: :model do
           cancel_effective_on: Date.new(2026, 5, 20),
           cancel_reason: "Cliente pediu pausa",
           expired_date: Date.new(2026, 5, 2),
-          expiration_warning_sent_at: Time.zone.local(2026, 5, 2, 11, 0, 0)
+          expiration_warning_sent_at: Time.zone.local(2026, 5, 2, 11, 0, 0),
+          expired_notification_sent_at: Time.zone.local(2026, 5, 7, 11, 0, 0)
         )
         started_at = Time.zone.local(2026, 5, 17, 9, 0, 0)
         period_end = Date.new(2026, 6, 17)
@@ -232,6 +233,7 @@ RSpec.describe Subscription, type: :model do
           expect(subscription.cancel_reason).to be_nil
           expect(subscription.expired_date).to be_nil
           expect(subscription.expiration_warning_sent_at).to be_nil
+          expect(subscription.expired_notification_sent_at).to be_nil
         end
       end
     end


### PR DESCRIPTION
## O que mudou

- Adiciona `Subscriptions::ExpirationMailer` para avisar quando uma assinatura é expirada.
- Dispara o email no command `Cmd::Subscriptions::ExpireOverdueSubscriptions`, após a transição para `expired`.
- Cria `expired_notification_sent_at` para evitar reenvio.
- Limpa o novo campo quando a assinatura é reativada por `activate!` ou por webhook de pagamento aprovado.
- Corrige acentuação em textos e logs próximos do fluxo de assinatura.

## Impacto

Empresas passam a receber uma comunicação explícita quando o acesso é expirado por assinatura vencida. O envio fica centralizado no command de expiração, sem callback na model.

## Validação

```sh
docker compose exec -T web env RAILS_ENV=test bundle exec rspec \
  spec/models/subscription_spec.rb \
  spec/commands/cmd/subscriptions/expire_overdue_subscriptions_spec.rb \
  spec/commands/cmd/subscriptions/notify_subscription_spec.rb \
  spec/mailers/subscriptions/expiration_mailer_spec.rb \
  spec/mailers/subscriptions/expiration_warning_mailer_spec.rb \
  spec/mailers/subscriptions/cancellation_mailer_spec.rb \
  spec/jobs/subscriptions/expire_overdue_subscriptions_job_spec.rb \
  spec/jobs/subscriptions/notify_overdue_subscriptions_job_spec.rb \
  spec/services/mercado_pago/webhook_processor_spec.rb
```

Resultado local: `77 examples, 0 failures`.