### PR TITLE
Ajusta cadastro Starter e emails de boas-vindas

### DIFF
--- a/app/controllers/register/signups_controller.rb
+++ b/app/controllers/register/signups_controller.rb
@@ -50,14 +50,14 @@ class Register::SignupsController < ApplicationController
     end
 
     if @company.plan&.free?
-      @user.send_welcome_email!
+      @user.send_starter_welcome_email!
       return redirect_to success_path(company_id: @company.id, starter: "1")
     elsif trial_coupon_without_mercado_pago?(coupon_result)
       @user.send_signup_confirmation_email!
       return redirect_to success_path(company_id: @company.id, confirmation_email: "1")
     end
 
-    @user.send_welcome_email! if should_send_welcome_email?(coupon_result)
+    @user.send_signup_welcome_email! if should_send_welcome_email?(coupon_result)
 
     redirect_to success_path(company_id: @company.id)
   end
@@ -90,6 +90,7 @@ class Register::SignupsController < ApplicationController
   def set_form_dependencies
     @payment_methods = %w[pix credit_card boleto]
     @plans = Plan.where(status: :active).order(:transaction_amount)
+    @selected_plan_id = selected_plan_for_form&.id
   end
 
   def company_params
@@ -275,6 +276,18 @@ class Register::SignupsController < ApplicationController
 
   def selected_plan
     @selected_plan ||= Plan.find_by(id: params.dig(:signup, :plan_id))
+  end
+
+  def selected_plan_for_form
+    plan_id = params.dig(:signup, :plan_id).presence || params[:plan_id].presence
+    return Plan.where(status: :active).find_by(id: plan_id) if plan_id.present?
+
+    plan_key = params[:plan].to_s.strip
+    return if plan_key.blank?
+
+    Plan.where(status: :active)
+        .where("LOWER(external_reference) = :key OR LOWER(name) = :key", key: plan_key.downcase)
+        .first
   end
 
 end

--- a/app/mailers/previews/user_mailer_preview.rb
+++ b/app/mailers/previews/user_mailer_preview.rb
@@ -5,5 +5,15 @@ module Previews
       token = "exemplo-token-reset"
       UserMailer.welcome_email(user, token)
     end
+
+    def starter_welcome_email
+      user = User.first || User.new(name: "Example User", email: "test@user.com")
+      UserMailer.starter_welcome_email(user)
+    end
+
+    def signup_welcome_email
+      user = User.first || User.new(name: "Example User", email: "test@user.com")
+      UserMailer.signup_welcome_email(user)
+    end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,18 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: "Confirme seu cadastro no CatalystOps")
   end
 
+  def starter_welcome_email(user)
+    @user = user
+    @login_url = login_root_url(subdomain: "login")
+    mail(to: @user.email, subject: "Seu plano Starter no CatalystOps está ativo!")
+  end
+
+  def signup_welcome_email(user)
+    @user = user
+    @login_url = login_root_url(subdomain: "login")
+    mail(to: @user.email, subject: "Sua conta no CatalystOps foi criada!")
+  end
+
   def reset_password_email(user, token)
     @user = user
     @reset_password_url = new_password_url(subdomain: "login", reset_password_token: token)

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -33,6 +33,7 @@ class Company < ApplicationRecord
   before_validation { self.email = email.to_s.downcase.strip if email.present? }
   before_validation :normalize_phone
   before_validation :normalize_zip_code
+  before_validation :normalize_website
   
   validates :payment_method, inclusion: { in: PAYMENT_METHODS }
   validates :name, presence: true, length: { minimum: 3 }
@@ -215,6 +216,13 @@ class Company < ApplicationRecord
 
   def normalize_phone
     self.phone = phone.to_s.gsub(/\D/, "") if phone.present?
+  end
+
+  def normalize_website
+    return if website.blank?
+
+    self.website = website.to_s.strip
+    self.website = "https://#{website}" unless website.match?(%r{\Ahttps?://}i)
   end
 
   def document_must_be_cpf_or_cnpj

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,22 @@ class User < ApplicationRecord
     update_column(:welcome_email_sent_at, Time.current) if mark_as_sent
   end
 
+  def send_starter_welcome_email!(mark_as_sent: true)
+    return false if welcome_email_sent_at.present?
+
+    UserMailer.starter_welcome_email(self).deliver_later
+    update_column(:welcome_email_sent_at, Time.current) if mark_as_sent
+    true
+  end
+
+  def send_signup_welcome_email!(mark_as_sent: true)
+    return false if welcome_email_sent_at.present?
+
+    UserMailer.signup_welcome_email(self).deliver_later
+    update_column(:welcome_email_sent_at, Time.current) if mark_as_sent
+    true
+  end
+
   def send_password_reset_email!
     token = set_reset_password_token
     UserMailer.reset_password_email(self, token).deliver_later

--- a/app/views/register/signups/new.html.erb
+++ b/app/views/register/signups/new.html.erb
@@ -170,7 +170,7 @@
 
                                   <div class="col-12 col-sm-6">
                                     <%= c.label :website, "Website (ou instagram, se preferir)", class: "form-label" %>
-                                    <%= c.url_field :website, class: "form-control", placeholder: "https://www.empresa.com" %>
+                                    <%= c.text_field :website, class: "form-control", placeholder: "https://www.empresa.com" %>
                                   </div>
 
                                   <div class="col-12 col-sm-6">
@@ -274,7 +274,12 @@
                                 <% @plans.each do |plan| %>
                                   <div class="col-12 col-md-6 col-xl-4">
                                     <label class="pm-card w-100" for="plan_<%= plan.id %>">
-                                      <%= f.radio_button :plan_id, plan.id, id: "plan_#{plan.id}", class: "pm-input", data: { plan_free: plan.free? } %>
+                                      <%= f.radio_button :plan_id,
+                                                         plan.id,
+                                                         id: "plan_#{plan.id}",
+                                                         class: "pm-input",
+                                                         checked: plan.id == @selected_plan_id,
+                                                         data: { plan_free: plan.free? } %>
                                       <div class="pm-content justify-content-between">
                                         <div class="d-flex align-items-center gap-2">
                                           <span class="pm-icon-wrap"><i class="bx bx-package pm-icon" aria-hidden="true"></i></span>

--- a/app/views/user_mailer/signup_welcome_email.html.erb
+++ b/app/views/user_mailer/signup_welcome_email.html.erb
@@ -1,0 +1,16 @@
+<title>Conta criada - CatalystOps</title>
+<h2 style="margin-top:0;">Bem-vindo, <%= @user.name %>!</h2>
+<p style="font-size:16px; line-height:1.6;">
+  Sua conta foi criada com sucesso.
+</p>
+<p style="font-size:16px; line-height:1.6;">
+  Use o e-mail e a senha definidos no cadastro para acessar o CatalystOps.
+</p>
+<div style="margin:32px 0;">
+  <a href="<%= @login_url %>" target="_blank" style="background:#0d6efd; color:#fff; text-decoration:none; padding:14px 32px; border-radius:4px; font-size:16px; font-weight:bold; display:inline-block;">
+    Acessar o sistema
+  </a>
+</div>
+<p style="font-size:14px; color:#888;">
+  Se você não reconhece este cadastro, ignore este e-mail.
+</p>

--- a/app/views/user_mailer/signup_welcome_email.text.erb
+++ b/app/views/user_mailer/signup_welcome_email.text.erb
@@ -1,0 +1,8 @@
+Olá, <%= @user.name %>!
+
+Sua conta foi criada com sucesso.
+
+Use o e-mail e a senha definidos no cadastro para acessar o CatalystOps:
+<%= @login_url %>
+
+Se você não reconhece este cadastro, ignore este e-mail.

--- a/app/views/user_mailer/starter_welcome_email.html.erb
+++ b/app/views/user_mailer/starter_welcome_email.html.erb
@@ -1,0 +1,16 @@
+<title>Plano Starter ativo - CatalystOps</title>
+<h2 style="margin-top:0;">Bem-vindo, <%= @user.name %>!</h2>
+<p style="font-size:16px; line-height:1.6;">
+  Seu cadastro foi criado com sucesso e seu plano Starter gratuito já está ativo.
+</p>
+<p style="font-size:16px; line-height:1.6;">
+  Use o e-mail e a senha definidos no cadastro para acessar o CatalystOps.
+</p>
+<div style="margin:32px 0;">
+  <a href="<%= @login_url %>" target="_blank" style="background:#0d6efd; color:#fff; text-decoration:none; padding:14px 32px; border-radius:4px; font-size:16px; font-weight:bold; display:inline-block;">
+    Acessar o sistema
+  </a>
+</div>
+<p style="font-size:14px; color:#888;">
+  Se você não reconhece este cadastro, ignore este e-mail.
+</p>

--- a/app/views/user_mailer/starter_welcome_email.text.erb
+++ b/app/views/user_mailer/starter_welcome_email.text.erb
@@ -1,0 +1,8 @@
+Olá, <%= @user.name %>!
+
+Seu cadastro foi criado com sucesso e seu plano Starter gratuito já está ativo.
+
+Use o e-mail e a senha definidos no cadastro para acessar o CatalystOps:
+<%= @login_url %>
+
+Se você não reconhece este cadastro, ignore este e-mail.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -27,6 +27,32 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe "#starter_welcome_email" do
+    it "envia link de acesso sem pedir redefinição de senha" do
+      email = described_class.starter_welcome_email(user)
+
+      aggregate_failures do
+        expect(email.to).to eq(["maria@example.com"])
+        expect(email.subject).to eq("Seu plano Starter no CatalystOps está ativo!")
+        expect(email.text_part.decoded).to include("Maria Usuária", "login.example.com")
+        expect(email.body.decoded).not_to include("reset_password_token", "Definir a nova senha")
+      end
+    end
+  end
+
+  describe "#signup_welcome_email" do
+    it "envia link de acesso sem pedir redefinição de senha" do
+      email = described_class.signup_welcome_email(user)
+
+      aggregate_failures do
+        expect(email.to).to eq(["maria@example.com"])
+        expect(email.subject).to eq("Sua conta no CatalystOps foi criada!")
+        expect(email.text_part.decoded).to include("Maria Usuária", "login.example.com")
+        expect(email.body.decoded).not_to include("reset_password_token", "Definir a nova senha")
+      end
+    end
+  end
+
   describe "#reset_password_email" do
     it "envia link de redefinição de senha" do
       email = described_class.reset_password_email(user, "reset-token")

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe Company, type: :model do
   end
 
   describe "escopos e estado" do
+    it "normaliza website sem protocolo para https" do
+      company = build(:company, website: "www.exemplo.com.br")
+
+      expect(company).to be_valid
+      expect(company.website).to eq("https://www.exemplo.com.br")
+    end
+
     it "retorna empresas com mais ordens de serviço primeiro" do
       company_with_two = company_with_subscription
       company_with_one = company_with_subscription

--- a/spec/requests/register/signups_controller_spec.rb
+++ b/spec/requests/register/signups_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Register::SignupsController", type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include(plan.name)
+    expect(response.body).to include('type="text" name="signup[company][website]"')
   end
 
   it "exibe plano Starter gratuito como Grátis" do
@@ -28,6 +29,17 @@ RSpec.describe "Register::SignupsController", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(starter.name)
       expect(response.body).to include("Grátis")
+    end
+  end
+
+  it "pré-seleciona o plano Starter quando informado pelo site" do
+    starter = create(:plan, :starter, status: "active")
+
+    get "/", params: { plan: "starter" }
+
+    aggregate_failures do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(/id="plan_#{starter.id}"[^>]*checked="checked"/)
     end
   end
 
@@ -45,15 +57,32 @@ RSpec.describe "Register::SignupsController", type: :request do
     expect(Audit::Log).to have_received(:call).with(hash_including(action: "terms.accepted", company: company))
   end
 
+  it "envia email de acesso sem redefinir senha para cadastro pago com cartão" do
+    allow(Cmd::MercadoPago::CreateCreditCardPayment).to receive(:new)
+      .and_return(instance_double("Result", call: Register::SignupsController::Result.new(true, nil)))
+    expect_any_instance_of(User).to receive(:send_signup_welcome_email!)
+
+    post "/signups", params: signup_params(payment_method: "credit_card").deep_merge(
+      signup: { card_token: "card-token" }
+    )
+
+    company = Company.order(:created_at).last
+    expect(response).to redirect_to(success_path(company_id: company.id))
+  end
+
   it "cria empresa, gestor técnico e assinatura ativa para plano Starter gratuito sem iniciar pagamento" do
     starter = create(:plan, :starter)
     allow(CreateUser::PixPaymentJob).to receive(:perform_later)
     allow(CreateUser::BoletoPaymentJob).to receive(:perform_later)
     allow(Cmd::MercadoPago::CreateCreditCardPayment).to receive(:new)
-    allow_any_instance_of(User).to receive(:send_welcome_email!)
+    expect_any_instance_of(User).to receive(:send_starter_welcome_email!)
 
     expect do
-      post "/signups", params: signup_params(plan_id: starter.id, payment_method: "credit_card")
+      post "/signups", params: signup_params(
+        plan_id: starter.id,
+        payment_method: "credit_card",
+        website: "www.beneditoejuanpublicidadeepropagandame.com.br"
+      )
     end.to change(Company, :count).by(1)
       .and change(User, :count).by(1)
       .and change(Subscription, :count).by(1)
@@ -70,6 +99,7 @@ RSpec.describe "Register::SignupsController", type: :request do
       expect(subscription).to be_active
       expect(subscription.end_date).to be_nil
       expect(subscription.transaction_amount).to eq(0)
+      expect(company.website).to eq("https://www.beneditoejuanpublicidadeepropagandame.com.br")
       expect(CreateUser::PixPaymentJob).not_to have_received(:perform_later)
       expect(CreateUser::BoletoPaymentJob).not_to have_received(:perform_later)
       expect(Cmd::MercadoPago::CreateCreditCardPayment).not_to have_received(:new)
@@ -99,7 +129,7 @@ RSpec.describe "Register::SignupsController", type: :request do
     expect(response.body).to include("Foi enviado")
   end
 
-  def signup_params(payment_method: "pix", accept_terms: "1", coupon_code: "", plan_id: plan.id)
+  def signup_params(payment_method: "pix", accept_terms: "1", coupon_code: "", plan_id: plan.id, website: nil)
     {
       signup: {
         plan_id: plan_id,
@@ -116,7 +146,8 @@ RSpec.describe "Register::SignupsController", type: :request do
           number: "123",
           neighborhood: "Centro",
           city: "São Paulo",
-          state: "SP"
+          state: "SP",
+          website: website
         },
         user: {
           name: "Gestor Baixa",


### PR DESCRIPTION
## O que mudou

- Permite que o cadastro aceite website sem protocolo, normalizando para `https://` antes da validação.
- Pré-seleciona o plano Starter quando o register recebe `?plan=starter`.
- Troca o email do cadastro Starter para um email de acesso, sem token de redefinição de senha.
- Troca o email do cadastro pago com cartão para um email de acesso, sem token de redefinição de senha.
- Mantém o fluxo de definição de senha para técnicos criados internamente e o fluxo normal de recuperação de senha.

## Por quê

O usuário já define a senha no register. O email de boas-vindas antigo gerava `reset_password_token` e orientava a criação de uma nova senha, o que não era necessário para novos cadastros feitos pelo register.

## Validação

- `docker compose exec -T web bundle exec rspec spec/mailers/user_mailer_spec.rb spec/models/user_spec.rb spec/requests/register/signups_controller_spec.rb`
- Resultado: `36 examples, 0 failures`