### PR TITLE
[codex] possibilita adesão a plano pago nas configurações

### DIFF
--- a/app/assets/javascripts/card_tokenization.js
+++ b/app/assets/javascripts/card_tokenization.js
@@ -95,7 +95,9 @@
     function shouldTokenize() {
       const method = form.querySelector('input[name="signup[payment_method]"]:checked')?.value;
       const ccForm = document.getElementById('credit-card-form');
-      const selectedPlan = form.querySelector('input[name="signup[plan_id]"]:checked');
+      const selectedPlan =
+        form.querySelector('input[name="signup[plan_id]"]:checked') ||
+        form.querySelector('input[type="hidden"][name="signup[plan_id]"]');
       const freePlanSelected = selectedPlan && selectedPlan.dataset.planFree === 'true';
       return method === 'credit_card' && !freePlanSelected && ccForm && !ccForm.classList.contains('d-none');
     }
@@ -141,6 +143,8 @@
             form.submit();
           },
           onError: (errors) => {
+            if (!shouldTokenize()) return;
+
             console.error('cardForm error', errors);
             alert('Erro ao tokenizar o cartão. Verifique os dados e tente novamente.');
           }

--- a/app/commands/cmd/mercado_pago/create_boleto_payment.rb
+++ b/app/commands/cmd/mercado_pago/create_boleto_payment.rb
@@ -4,9 +4,10 @@ module Cmd
       Result = Struct.new(:success?, :mailer_params, :errors)
       attr_reader :company, :plan, :response
 
-      def initialize(company, amount_override: nil)
+      def initialize(company, amount_override: nil, plan: nil, subscription: nil)
         @company = company
-        @plan = company.plan
+        @plan = plan || company.plan
+        @subscription = subscription || company.current_subscription
         @amount_override = amount_override
       end
 
@@ -85,7 +86,7 @@ module Cmd
         payment_id = response['id'].to_s
         return if payment_id.blank?
 
-        company.current_subscription&.update!(external_payment_id: payment_id)
+        @subscription&.update!(external_payment_id: payment_id)
       end
     end
   end

--- a/app/commands/cmd/mercado_pago/create_credit_card_payment.rb
+++ b/app/commands/cmd/mercado_pago/create_credit_card_payment.rb
@@ -4,9 +4,10 @@ module Cmd
       Result = Struct.new(:success?, :subscription, :errors)
       attr_reader :company, :plan, :cc_token, :response
 
-      def initialize(company, cc_token)
+      def initialize(company, cc_token, plan: nil, subscription: nil)
         @company = company
-        @plan = company.plan
+        @plan = plan || company.plan
+        @subscription = subscription || company.current_subscription
         @cc_token = cc_token
       end
 
@@ -21,7 +22,7 @@ module Cmd
           ::MercadoPago::MockData.create_credit_card_payment(credit_card_params)
         end
 
-        subscription = company.current_subscription
+        subscription = @subscription
 
         subscription.update!(
           external_reference: company.id.to_s,
@@ -31,7 +32,7 @@ module Cmd
 
         case response["status"]
         when "authorized"
-          subscription.activate!
+          subscription.activate_as_current!
           Result.new(true, subscription, nil)
         when "pending"
           subscription.update!(status: :pending)

--- a/app/commands/cmd/mercado_pago/create_pix_payment.rb
+++ b/app/commands/cmd/mercado_pago/create_pix_payment.rb
@@ -4,9 +4,10 @@ module Cmd
       Result = Struct.new(:success?, :mailer_params, :errors)
       attr_reader :company, :plan, :response
 
-      def initialize(company, amount_override: nil)
+      def initialize(company, amount_override: nil, plan: nil, subscription: nil)
         @company = company
-        @plan = company.plan
+        @plan = plan || company.plan
+        @subscription = subscription || company.current_subscription
         @amount_override = amount_override
       end
 
@@ -77,7 +78,7 @@ module Cmd
         payment_id = response['id'].to_s
         return if payment_id.blank?
 
-        company.current_subscription&.update!(external_payment_id: payment_id)
+        @subscription&.update!(external_payment_id: payment_id)
       end
     end
   end

--- a/app/controllers/app/configurations_controller.rb
+++ b/app/controllers/app/configurations_controller.rb
@@ -2,6 +2,9 @@ class App::ConfigurationsController < ApplicationController
   skip_authorization_check
   before_action :set_subscription_for_management, only: [:cancel_subscription, :resume_subscription]
   before_action :authorize_subscription_management, only: [:cancel_subscription, :resume_subscription]
+  before_action :authorize_paid_subscription_start, only: [:start_paid_subscription]
+
+  Result = Struct.new(:success?, :errors)
 
   def index; end
 
@@ -117,6 +120,48 @@ class App::ConfigurationsController < ApplicationController
     end
   end
 
+  def start_paid_subscription
+    company = current_user.company
+    plan = paid_subscription_plan
+    payment_method = subscription_payment_method
+
+    if plan.blank?
+      redirect_to app_configurations_path(tab: "assinatura"), alert: "Selecione um plano pago ativo."
+      return
+    end
+
+    unless Company::PAYMENT_METHODS.include?(payment_method)
+      redirect_to app_configurations_path(tab: "assinatura"), alert: "Selecione uma forma de pagamento válida."
+      return
+    end
+
+    if company.current_active_subscription&.free_plan? != true
+      redirect_to app_configurations_path(tab: "assinatura"), alert: "A adesão pela tela de configurações está disponível apenas para o plano Starter."
+      return
+    end
+
+    if payment_method == "credit_card" && params.dig(:signup, :card_token).blank?
+      redirect_to app_configurations_path(tab: "assinatura"), alert: "Token do cartão não informado."
+      return
+    end
+
+    subscription = create_pending_paid_subscription!(company, plan, payment_method)
+    payment_result = start_paid_subscription_payment(company, plan, subscription, payment_method)
+
+    unless payment_result.success?
+      subscription.update_columns(status: Subscription.statuses[:cancelled], canceled_date: Time.current, updated_at: Time.current)
+      redirect_to app_configurations_path(tab: "assinatura"), alert: "Houve falha ao iniciar o pagamento: #{payment_result.errors}"
+      return
+    end
+
+    audit_paid_subscription_start(company, plan, subscription, payment_method)
+
+    redirect_to app_configurations_path(tab: "assinatura"),
+                notice: paid_subscription_notice(payment_method)
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to app_configurations_path(tab: "assinatura"), alert: e.record.errors.full_messages.to_sentence
+  end
+
   def cancel_subscription
     return redirect_to app_configurations_path, alert: "O plano Starter não possui cancelamento de assinatura." if @subscription.free_plan?
     return redirect_to app_configurations_path, alert: "Assinatura não está ativa para cancelamento." unless @subscription.active?
@@ -213,8 +258,96 @@ class App::ConfigurationsController < ApplicationController
     document_type == "budget" ? "orçamento" : "ordem de serviço"
   end
 
+  def paid_subscription_plan
+    Plan.paid.where(status: :active).find_by(id: params.dig(:signup, :plan_id))
+  end
+
+  def subscription_payment_method
+    params.dig(:signup, :payment_method).to_s
+  end
+
+  def create_pending_paid_subscription!(company, plan, payment_method)
+    ActiveRecord::Base.transaction do
+      company.subscriptions.pending.where.not(preapproval_plan_id: company.current_active_subscription&.preapproval_plan_id).update_all(
+        status: Subscription.statuses[:cancelled],
+        canceled_date: Time.current,
+        updated_at: Time.current
+      )
+
+      company.update!(payment_method: payment_method)
+
+      company.subscriptions.create!(
+        preapproval_plan_id: plan.external_id,
+        reason: plan.reason,
+        transaction_amount: plan.transaction_amount,
+        external_reference: company.id.to_s,
+        status: :pending,
+        raw_payload: {
+          "source" => "app_configurations",
+          "selected_payment_method" => payment_method
+        }
+      )
+    end
+  end
+
+  def start_paid_subscription_payment(company, plan, subscription, payment_method)
+    case payment_method
+    when "boleto"
+      CreateUser::BoletoPaymentJob.perform_later(company.id, plan_id: plan.id, subscription_id: subscription.id)
+      Result.new(true, nil)
+    when "pix"
+      CreateUser::PixPaymentJob.perform_later(company.id, plan_id: plan.id, subscription_id: subscription.id)
+      Result.new(true, nil)
+    when "credit_card"
+      Cmd::MercadoPago::CreateCreditCardPayment.new(
+        company,
+        params.dig(:signup, :card_token),
+        plan: plan,
+        subscription: subscription
+      ).call
+    else
+      Result.new(false, "Método de pagamento inválido.")
+    end
+  end
+
+  def paid_subscription_notice(payment_method)
+    case payment_method
+    when "credit_card"
+      "Adesão iniciada com sucesso. A assinatura será ativada após a aprovação do cartão."
+    when "pix"
+      "Adesão iniciada com sucesso. Enviaremos as instruções de pagamento por PIX para o e-mail da empresa."
+    when "boleto"
+      "Adesão iniciada com sucesso. Enviaremos o boleto para o e-mail da empresa."
+    end
+  end
+
+  def audit_paid_subscription_start(company, plan, subscription, payment_method)
+    Audit::Log.call(
+      action: "subscription.paid_signup.started",
+      actor: current_user,
+      company: company,
+      resource: subscription,
+      metadata: {
+        event: "paid_signup_started",
+        origin: "app_configurations_subscription",
+        selected_payment_method: payment_method,
+        previous_subscription_id: company.current_active_subscription&.id,
+        selected_plan: {
+          id: plan.id,
+          external_id: plan.external_id,
+          name: plan.name,
+          transaction_amount: plan.transaction_amount
+        },
+        pending_subscription: {
+          id: subscription.id,
+          status: subscription.status
+        }
+      }
+    )
+  end
+
   def set_subscription_for_management
-    @subscription = current_user.company&.current_subscription
+    @subscription = current_user.company&.current_active_subscription
     return if @subscription.present?
 
     redirect_to app_configurations_path, alert: "Nenhuma assinatura ativa encontrada."
@@ -224,5 +357,10 @@ class App::ConfigurationsController < ApplicationController
     return if performed?
 
     authorize! :manage, @subscription
+  end
+
+  def authorize_paid_subscription_start
+    subscription = current_user.company&.current_active_subscription || current_user.company&.subscriptions&.build
+    authorize! :manage, subscription
   end
 end

--- a/app/helpers/configurations_helper.rb
+++ b/app/helpers/configurations_helper.rb
@@ -28,6 +28,35 @@ module ConfigurationsHelper
     user.company.subscriptions.find_by(status: :active)
   end
 
+  def paid_subscription_plans
+    Plan.paid.where(status: :active).order(:transaction_amount)
+  end
+
+  def configuration_payment_methods
+    Company::PAYMENT_METHODS
+  end
+
+  def configuration_payment_method_label(method)
+    case method.to_s
+    when "pix"
+      "PIX"
+    when "credit_card"
+      "Cartão"
+    when "boleto"
+      "Boleto"
+    else
+      method.to_s.humanize
+    end
+  end
+
+  def configuration_payment_method_icon(method)
+    {
+      "pix" => "bx-money",
+      "credit_card" => "bx-credit-card",
+      "boleto" => "bx-barcode"
+    }[method.to_s] || "bx-credit-card"
+  end
+
   def subscription_badge_class(status)
     case status.to_s
     when "active"

--- a/app/jobs/create_user/boleto_payment_job.rb
+++ b/app/jobs/create_user/boleto_payment_job.rb
@@ -1,13 +1,20 @@
 class CreateUser::BoletoPaymentJob < ApplicationJob
   queue_as :default
 
-  def perform(company_id, coupon_id: nil, original_amount: nil, final_amount: nil)
+  def perform(company_id, coupon_id: nil, original_amount: nil, final_amount: nil, plan_id: nil, subscription_id: nil)
     company = Company.find_by(id: company_id)
+    plan = Plan.find_by(id: plan_id) || company.plan
+    subscription = Subscription.find_by(id: subscription_id) || company.current_subscription
     
-    result = Cmd::MercadoPago::CreateBoletoPayment.new(company, amount_override: final_amount).call
+    result = Cmd::MercadoPago::CreateBoletoPayment.new(
+      company,
+      amount_override: final_amount,
+      plan: plan,
+      subscription: subscription
+    ).call
 
     if result.success?
-      redeem_coupon(company, coupon_id, original_amount, final_amount)
+      redeem_coupon(company, subscription, coupon_id, original_amount, final_amount)
       Payments::BoletoMailer.with(result.mailer_params).ticket_email.deliver_later
       Rails.logger.info("[CreateUser::BoletoPaymentJob] E-mail de pagamento boleto enviado para Company ID #{company_id}.")
     else
@@ -17,13 +24,13 @@ class CreateUser::BoletoPaymentJob < ApplicationJob
 
   private
 
-  def redeem_coupon(company, coupon_id, original_amount, final_amount)
+  def redeem_coupon(company, subscription, coupon_id, original_amount, final_amount)
     return if coupon_id.blank?
 
     Coupons::Redeem.call(
       coupon: Coupon.find(coupon_id),
       company: company,
-      subscription: company.current_subscription,
+      subscription: subscription,
       original_amount: original_amount,
       final_amount: final_amount
     )

--- a/app/jobs/create_user/pix_payment_job.rb
+++ b/app/jobs/create_user/pix_payment_job.rb
@@ -1,13 +1,20 @@
 class CreateUser::PixPaymentJob < ApplicationJob
   queue_as :default
 
-  def perform(company_id, coupon_id: nil, original_amount: nil, final_amount: nil)
+  def perform(company_id, coupon_id: nil, original_amount: nil, final_amount: nil, plan_id: nil, subscription_id: nil)
     company = Company.find(company_id)
+    plan = Plan.find_by(id: plan_id) || company.plan
+    subscription = Subscription.find_by(id: subscription_id) || company.current_subscription
 
-    result = Cmd::MercadoPago::CreatePixPayment.new(company, amount_override: final_amount).call
+    result = Cmd::MercadoPago::CreatePixPayment.new(
+      company,
+      amount_override: final_amount,
+      plan: plan,
+      subscription: subscription
+    ).call
 
     if result.success?
-      redeem_coupon(company, coupon_id, original_amount, final_amount)
+      redeem_coupon(company, subscription, coupon_id, original_amount, final_amount)
       Payments::PixMailer.with(result.mailer_params).pix_email.deliver_later
       
       Rails.logger.info("[CreateUser::PixPaymentJob] E-mail de pagamento Pix enviado para Company ID #{company_id}.")
@@ -18,13 +25,13 @@ class CreateUser::PixPaymentJob < ApplicationJob
 
   private
 
-  def redeem_coupon(company, coupon_id, original_amount, final_amount)
+  def redeem_coupon(company, subscription, coupon_id, original_amount, final_amount)
     return if coupon_id.blank?
 
     Coupons::Redeem.call(
       coupon: Coupon.find(coupon_id),
       company: company,
-      subscription: company.current_subscription,
+      subscription: subscription,
       original_amount: original_amount,
       final_amount: final_amount
     )

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -169,23 +169,27 @@ class Company < ApplicationRecord
   end
 
   def current_plan
-    subscriptions.current.first&.plan  
+    current_active_subscription&.plan || subscriptions.current.first&.plan || plan
+  end
+
+  def current_active_subscription
+    subscriptions.active_records.recent.first
   end
 
   def max_technicians
-    current_subscription.plan&.max_technicians
+    current_plan&.max_technicians
   end
   
   def max_orders
-    current_subscription.plan&.max_orders
+    current_plan&.max_orders
   end
 
   def max_budgets
-    current_subscription.plan&.max_budgets
+    current_plan&.max_budgets
   end
 
   def support_level
-    current_subscription.plan&.support_level
+    current_plan&.support_level
   end
 
   def can_add_technician?
@@ -238,6 +242,6 @@ class Company < ApplicationRecord
   end
 
   def adimplente?
-    current_subscription&.active? || false
+    current_active_subscription.present?
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -70,6 +70,19 @@ class Subscription < ApplicationRecord
     activate_for!
   end
 
+  def activate_as_current!(frequency: 1, frequency_type: "months", started_at: Time.current)
+    transaction do
+      activate_for!(frequency: frequency, frequency_type: frequency_type, started_at: started_at)
+
+      company.subscriptions
+             .where(status: :active)
+             .where.not(id: id)
+             .update_all(status: :cancelled, canceled_date: Time.current, updated_at: Time.current)
+
+      company.update!(plan: plan) if plan.present?
+    end
+  end
+
   def activate_for!(frequency: 1, frequency_type: "months", started_at: Time.current)
     period_end = MercadoPago::Subscriptions.compute_period_end(
       started_at,

--- a/app/services/audit/action_catalog.rb
+++ b/app/services/audit/action_catalog.rb
@@ -87,6 +87,7 @@ module Audit
       subscription.payment.pending
       subscription.payment.approved
       subscription.payment.failed
+      subscription.paid_signup.started
       subscription.reconciled
       subscription.reprocess.pending_payment
     ].freeze

--- a/app/services/mercado_pago/webhook_processor.rb
+++ b/app/services/mercado_pago/webhook_processor.rb
@@ -58,7 +58,7 @@ module MercadoPago
 
       case payment["status"].to_s
       when "approved"
-        subscription.activate!
+        subscription.activate_as_current!
         log_subscription_payment_event!(
           action: "subscription.payment.approved",
           subscription: subscription,
@@ -111,7 +111,7 @@ module MercadoPago
 
       case preapproval["status"]
       when "authorized"
-        subscription.activate!
+        subscription.activate_as_current!
       when "paused", "cancelled"
         subscription.cancel!
       when "pending"
@@ -136,17 +136,8 @@ module MercadoPago
       return Result.new(true, "Authorized payment #{authorized_payment_id} ignorado com status #{authorized_payment.dig('payment', 'status')}") unless authorized_payment.dig("payment", "status") == "approved"
 
       paid_at = parse_time(authorized_payment["debit_date"]) || Time.current
-      period_end = MercadoPago::Subscriptions.compute_period_end(paid_at)
 
-      subscription.update!(
-        status: :active,
-        start_date: paid_at.to_date,
-        end_date: period_end.to_date,
-        canceled_date: nil,
-        expired_date: nil,
-        expiration_warning_sent_at: nil,
-        expired_notification_sent_at: nil
-      )
+      subscription.activate_as_current!(started_at: paid_at)
 
       Result.new(true, "Authorized payment #{authorized_payment_id} processado com sucesso")
     end

--- a/app/views/app/configurations/_subscription.html.erb
+++ b/app/views/app/configurations/_subscription.html.erb
@@ -3,7 +3,7 @@
     <h5 class="card-title mb-0">Assinatura</h5>
   </div>
   <div class="card-body p-4">
-    <% subscription = current_user.company.current_subscription %>
+    <% subscription = current_user.company.current_active_subscription || current_user.company.current_subscription %>
     <% if subscription && subscription.plan %>
       <div class="row mb-2">
         <div class="col-md-4 text-secondary"><strong>Plano:</strong></div>
@@ -52,7 +52,73 @@
         <div class="col-md-8"><%= subscription.plan.support_level %></div>
       </div>
 
-      <% unless subscription.free_plan? %>
+      <% if subscription.free_plan? %>
+        <hr class="my-4">
+
+        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+          <div>
+            <h6 class="mb-1">Planos pagos disponíveis</h6>
+            <p class="text-muted mb-0">Compare os planos e escolha uma opção para continuar.</p>
+          </div>
+        </div>
+
+        <% paid_plans = paid_subscription_plans %>
+        <% if paid_plans.any? %>
+          <div class="row g-3">
+            <% paid_plans.each do |plan| %>
+              <div class="col-12 col-lg-6 col-xl-4">
+                <button type="button"
+                        class="card h-100 w-100 border shadow-sm text-start bg-white paid-subscription-card js-paid-subscription-plan"
+                        data-bs-toggle="modal"
+                        data-bs-target="#paidSubscriptionModal"
+                        data-plan-id="<%= plan.id %>"
+                        data-plan-name="<%= plan.name %>"
+                        data-plan-amount="<%= number_to_currency(plan.transaction_amount, unit: "R$ ") %>">
+                  <div class="card-body d-flex flex-column">
+                    <div class="d-flex align-items-start justify-content-between gap-3 mb-3">
+                      <div>
+                        <h6 class="card-title mb-1"><%= plan.name %></h6>
+                        <p class="text-muted small mb-0"><%= plan.reason %></p>
+                      </div>
+                      <div class="text-end flex-shrink-0">
+                        <div class="fw-bold"><%= number_to_currency(plan.transaction_amount, unit: "R$ ") %></div>
+                        <small class="text-muted">por mês</small>
+                      </div>
+                    </div>
+
+                    <div class="border-top pt-3 mb-3">
+                      <div class="d-flex justify-content-between gap-3 small mb-2">
+                        <span class="text-secondary">Técnicos</span>
+                        <strong><%= plan.max_technicians || "Ilimitado" %></strong>
+                      </div>
+                      <div class="d-flex justify-content-between gap-3 small mb-2">
+                        <span class="text-secondary">Ordens</span>
+                        <strong><%= plan.max_orders || "Ilimitado" %></strong>
+                      </div>
+                      <div class="d-flex justify-content-between gap-3 small mb-2">
+                        <span class="text-secondary">Orçamentos</span>
+                        <strong><%= plan.max_budgets || "Ilimitado" %></strong>
+                      </div>
+                      <div class="d-flex justify-content-between gap-3 small">
+                        <span class="text-secondary">Suporte</span>
+                        <strong class="text-end"><%= plan.support_level.presence || "Não informado" %></strong>
+                      </div>
+                    </div>
+
+                    <div class="mt-auto">
+                      <span class="btn btn-primary w-100 pe-none">Escolher plano</span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="alert alert-info mb-0">
+            Nenhum plano pago disponível no momento.
+          </div>
+        <% end %>
+      <% else %>
         <hr class="my-4">
         <h6 class="mb-3">Cancelamento</h6>
 
@@ -89,3 +155,149 @@
     <% end %>
   </div>
 </div>
+
+<% if subscription&.free_plan? %>
+  <div class="modal fade" id="paidSubscriptionModal" tabindex="-1" aria-labelledby="paidSubscriptionModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <%= form_with url: start_paid_subscription_app_configurations_path,
+                      method: :post,
+                      local: true,
+                      html: { id: "signup-form", data: { paid_subscription_form: true } } do %>
+          <div class="modal-header">
+            <div>
+              <h5 class="modal-title" id="paidSubscriptionModalLabel">Adesão ao plano pago</h5>
+              <p class="text-muted mb-0 small" id="paidSubscriptionModalSubtitle">Selecione a forma de pagamento para continuar.</p>
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+
+          <div class="modal-body">
+            <input type="hidden" name="signup[plan_id]" id="paid_subscription_plan_id">
+            <input type="hidden" name="signup[company][email]" value="<%= current_user.company.email %>">
+
+            <h6 class="mb-2">Forma de pagamento</h6>
+            <div class="payment-methods d-flex gap-3 flex-wrap mb-3">
+              <% configuration_payment_methods.each do |payment_method| %>
+                <label class="border rounded px-3 py-2 d-inline-flex align-items-center gap-2 paid-subscription-payment-option" for="paid_subscription_payment_method_<%= payment_method %>">
+                  <input type="checkbox"
+                         name="signup[payment_method]"
+                         value="<%= payment_method %>"
+                         id="paid_subscription_payment_method_<%= payment_method %>"
+                         class="form-check-input m-0 pm-input paid-subscription-payment-checkbox">
+                  <i class="bx <%= configuration_payment_method_icon(payment_method) %>" aria-hidden="true"></i>
+                  <span><%= configuration_payment_method_label(payment_method) %></span>
+                </label>
+              <% end %>
+            </div>
+
+            <div id="credit-card-form" class="card border d-none">
+              <div class="card-body">
+                <h6 class="mb-3">Dados do Cartão</h6>
+                <div class="row g-3">
+                  <div class="col-12 col-md-6">
+                    <label class="form-label">Nome impresso no cartão</label>
+                    <input type="text" name="signup[card][cardholder_name]" class="form-control" placeholder="Fulano de Tal">
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <label class="form-label">CPF do titular</label>
+                    <input type="text" name="signup[card][cardholder_document]" class="form-control" placeholder="000.000.000-00">
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <label class="form-label">Número do cartão</label>
+                    <input type="text" name="signup[card][card_number]" class="form-control" inputmode="numeric" placeholder="4111 1111 1111 1111">
+                  </div>
+                  <div class="col-6 col-md-3">
+                    <label class="form-label">Validade (MM/AA)</label>
+                    <input type="text" name="signup[card][card_expiration]" class="form-control" placeholder="12/28">
+                  </div>
+                  <div class="col-6 col-md-3">
+                    <label class="form-label">CVV</label>
+                    <input type="password" name="signup[card][card_cvv]" class="form-control" inputmode="numeric" placeholder="123">
+                  </div>
+                  <div class="col-12">
+                    <small class="text-muted">
+                      Seus dados serão tokenizados com segurança pelo Mercado Pago.
+                    </small>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Voltar</button>
+            <button type="submit" class="btn btn-primary">Continuar</button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://sdk.mercadopago.com/js/v2"></script>
+  <%= javascript_include_tag "payment_method_toggle", defer: true %>
+  <%= javascript_include_tag "card_tokenization", defer: true %>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var modalTitle = document.getElementById("paidSubscriptionModalLabel");
+      var modalSubtitle = document.getElementById("paidSubscriptionModalSubtitle");
+      var planInput = document.getElementById("paid_subscription_plan_id");
+
+      document.querySelectorAll(".js-paid-subscription-plan").forEach(function (button) {
+        button.addEventListener("click", function () {
+          planInput.value = button.dataset.planId;
+          modalTitle.textContent = "Adesão ao plano " + button.dataset.planName;
+          modalSubtitle.textContent = button.dataset.planAmount + " por mês. Selecione a forma de pagamento para continuar.";
+        });
+      });
+
+      document.querySelectorAll(".paid-subscription-payment-checkbox").forEach(function (checkbox) {
+        checkbox.addEventListener("change", function () {
+          if (checkbox.checked) {
+            document.querySelectorAll(".paid-subscription-payment-checkbox").forEach(function (otherCheckbox) {
+              if (otherCheckbox !== checkbox) otherCheckbox.checked = false;
+            });
+          }
+
+          document.querySelectorAll(".paid-subscription-payment-option").forEach(function (option) {
+            var optionCheckbox = option.querySelector(".paid-subscription-payment-checkbox");
+            option.classList.toggle("active", optionCheckbox && optionCheckbox.checked);
+          });
+        });
+      });
+    });
+  </script>
+  <style>
+    .paid-subscription-card {
+      border-radius: 0.5rem;
+      transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+    }
+
+    .paid-subscription-card:hover,
+    .paid-subscription-card:focus {
+      border-color: rgba(13, 110, 253, 0.35);
+      box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.16) !important;
+      transform: scale(1.015);
+    }
+
+    .paid-subscription-card:focus {
+      outline: 0;
+    }
+
+    .paid-subscription-card:focus-visible {
+      box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25), 0 0.75rem 1.75rem rgba(15, 23, 42, 0.16) !important;
+    }
+
+    .paid-subscription-payment-option {
+      cursor: pointer;
+      transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+    }
+
+    .paid-subscription-payment-option:hover,
+    .paid-subscription-payment-option.active {
+      border-color: rgba(13, 110, 253, 0.55) !important;
+      background-color: rgba(13, 110, 253, 0.06);
+      box-shadow: 0 0.35rem 0.9rem rgba(15, 23, 42, 0.08);
+    }
+  </style>
+<% end %>

--- a/app/views/app/configurations/index.html.erb
+++ b/app/views/app/configurations/index.html.erb
@@ -1,3 +1,9 @@
+<% if ENV["MP_PUBLIC_KEY"].present? %>
+  <% content_for :head do %>
+    <meta name="mp-public-key" content="<%= ENV["MP_PUBLIC_KEY"] %>">
+  <% end %>
+<% end %>
+
 <div class="page-wrapper configurations-page">
   <div class="page-content">
     <% active_tab = @active_config_tab.presence || params[:tab].presence || "perfil" %>

--- a/config/routes/app.rb
+++ b/config/routes/app.rb
@@ -54,6 +54,7 @@ constraints subdomain: "app" do
       patch :update_pdf_settings
       delete :remove_pdf_logo
       get :preview_pdf_settings
+      post :start_paid_subscription
       patch :cancel_subscription
       patch :resume_subscription
       post :promote_manager

--- a/spec/controllers/app/configurations_controller_spec.rb
+++ b/spec/controllers/app/configurations_controller_spec.rb
@@ -396,11 +396,11 @@ RSpec.describe App::ConfigurationsController, type: :controller do
 
         patch :cancel_subscription
 
-        aggregate_failures do
-          expect(response).to redirect_to(app_configurations_path)
-          expect(flash[:alert]).to eq("Assinatura não está ativa para cancelamento.")
-          expect(Subscriptions::CancellationMailer).not_to have_received(:with)
-        end
+      aggregate_failures do
+        expect(response).to redirect_to(app_configurations_path)
+        expect(flash[:alert]).to eq("Nenhuma assinatura ativa encontrada.")
+        expect(Subscriptions::CancellationMailer).not_to have_received(:with)
+      end
       end
 
       it "redireciona quando não existe assinatura atual" do
@@ -488,6 +488,124 @@ RSpec.describe App::ConfigurationsController, type: :controller do
           expect(flash[:alert]).to eq("Falha ao reativar")
           expect(subscription.reload.cancel_at_period_end).to be(true)
         end
+      end
+    end
+  end
+
+  describe "adesão a plano pago" do
+    let(:starter_plan) { create(:plan, :starter) }
+    let(:paid_plan) { create(:plan, :profissional) }
+    let(:company) { create(:company, plan: starter_plan, active: true, payment_method: "boleto") }
+    let(:user) { create(:user, :gestor, company: company, active: true) }
+    let!(:starter_subscription) { create(:subscription, company: company, subscription_plan: starter_plan, status: :active) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(CreateUser::PixPaymentJob).to receive(:perform_later)
+      allow(CreateUser::BoletoPaymentJob).to receive(:perform_later)
+      allow(Audit::Log).to receive(:call)
+    end
+
+    it "cria assinatura paga pendente e agenda pagamento pix mantendo Starter ativo" do
+      post :start_paid_subscription, params: {
+        signup: {
+          plan_id: paid_plan.id,
+          payment_method: "pix"
+        }
+      }
+
+      pending_subscription = company.subscriptions.order(created_at: :desc).first
+
+      aggregate_failures do
+        expect(response).to redirect_to(app_configurations_path(tab: "assinatura"))
+        expect(flash[:notice]).to include("Adesão iniciada com sucesso")
+        expect(pending_subscription).to be_pending
+        expect(pending_subscription.plan).to eq(paid_plan)
+        expect(company.reload.payment_method).to eq("pix")
+        expect(starter_subscription.reload).to be_active
+        expect(company.current_active_subscription).to eq(starter_subscription)
+        expect(CreateUser::PixPaymentJob).to have_received(:perform_later).with(
+          company.id,
+          plan_id: paid_plan.id,
+          subscription_id: pending_subscription.id
+        )
+        expect(Audit::Log).to have_received(:call).with(
+          action: "subscription.paid_signup.started",
+          actor: user,
+          company: company,
+          resource: pending_subscription,
+          metadata: hash_including(
+            event: "paid_signup_started",
+            origin: "app_configurations_subscription",
+            selected_payment_method: "pix",
+            previous_subscription_id: starter_subscription.id,
+            selected_plan: hash_including(
+              id: paid_plan.id,
+              external_id: paid_plan.external_id,
+              name: paid_plan.name,
+              transaction_amount: paid_plan.transaction_amount
+            ),
+            pending_subscription: hash_including(
+              id: pending_subscription.id,
+              status: "pending"
+            )
+          )
+        )
+      end
+    end
+
+    it "cria assinatura paga pendente e agenda boleto" do
+      post :start_paid_subscription, params: {
+        signup: {
+          plan_id: paid_plan.id,
+          payment_method: "boleto"
+        }
+      }
+
+      pending_subscription = company.subscriptions.order(created_at: :desc).first
+
+      aggregate_failures do
+        expect(response).to redirect_to(app_configurations_path(tab: "assinatura"))
+        expect(company.reload.payment_method).to eq("boleto")
+        expect(CreateUser::BoletoPaymentJob).to have_received(:perform_later).with(
+          company.id,
+          plan_id: paid_plan.id,
+          subscription_id: pending_subscription.id
+        )
+      end
+    end
+
+    it "bloqueia cartão sem token" do
+      post :start_paid_subscription, params: {
+        signup: {
+          plan_id: paid_plan.id,
+          payment_method: "credit_card"
+        }
+      }
+
+      aggregate_failures do
+        expect(response).to redirect_to(app_configurations_path(tab: "assinatura"))
+        expect(flash[:alert]).to eq("Token do cartão não informado.")
+        expect(company.subscriptions.where(status: :pending)).to be_empty
+      end
+    end
+
+    it "bloqueia adesão quando empresa não está no Starter" do
+      paid_company_plan = create(:plan, name: "Basico", external_reference: "BASICO_ADESAO", transaction_amount: 99)
+      starter_subscription.update!(preapproval_plan_id: paid_company_plan.external_id, reason: paid_company_plan.reason, transaction_amount: paid_company_plan.transaction_amount)
+      company.update!(plan: paid_company_plan)
+
+      post :start_paid_subscription, params: {
+        signup: {
+          plan_id: paid_plan.id,
+          payment_method: "pix"
+        }
+      }
+
+      aggregate_failures do
+        expect(response).to redirect_to(app_configurations_path(tab: "assinatura"))
+        expect(flash[:alert]).to eq("A adesão pela tela de configurações está disponível apenas para o plano Starter.")
+        expect(CreateUser::PixPaymentJob).not_to have_received(:perform_later)
       end
     end
   end

--- a/spec/jobs/create_user/payment_jobs_spec.rb
+++ b/spec/jobs/create_user/payment_jobs_spec.rb
@@ -8,30 +8,49 @@ RSpec.describe "Jobs de criação de pagamento", type: :job do
       command = instance_double(Cmd::MercadoPago::CreateBoletoPayment, call: result)
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
 
-      allow(Cmd::MercadoPago::CreateBoletoPayment).to receive(:new).with(company, amount_override: 90).and_return(command)
       allow(Payments::BoletoMailer).to receive(:with).with(result.mailer_params).and_return(double(ticket_email: mail))
       allow(Coupons::Redeem).to receive(:call)
       allow(Coupon).to receive(:find).with("coupon-id").and_return(double("Coupon"))
-      allow(company).to receive(:current_subscription).and_return(double("Subscription"))
+      subscription = double("Subscription")
+      allow(company).to receive(:current_subscription).and_return(subscription)
+      allow(Cmd::MercadoPago::CreateBoletoPayment).to receive(:new).with(
+        company,
+        amount_override: 90,
+        plan: company.plan,
+        subscription: subscription
+      ).and_return(command)
       allow(Company).to receive(:find_by).with(id: company.id).and_return(company)
 
       described_class.new.perform(company.id, coupon_id: "coupon-id", original_amount: 100, final_amount: 90)
 
       aggregate_failures do
         expect(mail).to have_received(:deliver_later)
-        expect(Coupons::Redeem).to have_received(:call).with(hash_including(company: company, original_amount: 100, final_amount: 90))
+        expect(Cmd::MercadoPago::CreateBoletoPayment).to have_received(:new).with(
+          company,
+          amount_override: 90,
+          plan: company.plan,
+          subscription: subscription
+        )
+        expect(Coupons::Redeem).to have_received(:call).with(hash_including(company: company, subscription: subscription, original_amount: 100, final_amount: 90))
       end
     end
   end
 
   describe CreateUser::PixPaymentJob do
     it "cria pix e envia e-mail" do
-      company = create(:company)
+      plan = create(:plan)
+      company = create(:company, plan: plan)
+      subscription = create(:subscription, company: company, subscription_plan: plan)
       result = Cmd::MercadoPago::CreatePixPayment::Result.new(true, { company: company }, nil)
       command = instance_double(Cmd::MercadoPago::CreatePixPayment, call: result)
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
 
-      allow(Cmd::MercadoPago::CreatePixPayment).to receive(:new).with(company, amount_override: nil).and_return(command)
+      allow(Cmd::MercadoPago::CreatePixPayment).to receive(:new).with(
+        company,
+        amount_override: nil,
+        plan: plan,
+        subscription: subscription
+      ).and_return(command)
       allow(Payments::PixMailer).to receive(:with).with(result.mailer_params).and_return(double(pix_email: mail))
 
       described_class.new.perform(company.id)

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe Company, type: :model do
       end
     end
 
+    it "mantém plano e acesso da assinatura ativa quando existe pagamento pendente" do
+      starter = create(:plan, :starter)
+      paid_plan = create(:plan, :profissional, max_technicians: 5)
+      company = create(:company, plan: starter)
+      active_subscription = create(:subscription, company: company, subscription_plan: starter, status: :active)
+      create(:subscription, company: company, subscription_plan: paid_plan, status: :pending)
+
+      aggregate_failures do
+        expect(company.current_active_subscription).to eq(active_subscription)
+        expect(company.current_plan).to eq(starter)
+        expect(company.max_technicians).to eq(1)
+        expect(company).to be_access_enabled
+      end
+    end
+
     it "valida se pode adicionar técnico respeitando limite" do
       plan = create(:plan, max_technicians: 1)
       company = create(:company, plan: plan)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -664,4 +664,24 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe "#activate_as_current!" do
+    it "ativa a assinatura paga, cancela a Starter anterior e atualiza o plano da empresa" do
+      starter = create(:plan, :starter)
+      paid_plan = create(:plan, :profissional)
+      company = create(:company, plan: starter, active: true)
+      starter_subscription = create(:subscription, company: company, subscription_plan: starter, status: :active)
+      paid_subscription = create(:subscription, company: company, subscription_plan: paid_plan, status: :pending)
+
+      paid_subscription.activate_as_current!(started_at: Time.zone.local(2026, 6, 25, 10, 0, 0))
+
+      aggregate_failures do
+        expect(paid_subscription.reload).to be_active
+        expect(starter_subscription.reload).to be_cancelled
+        expect(company.reload.plan).to eq(paid_plan)
+        expect(company.current_active_subscription).to eq(paid_subscription)
+        expect(company).to be_active
+      end
+    end
+  end
 end

--- a/spec/views/app/configurations/_subscription.html.erb_spec.rb
+++ b/spec/views/app/configurations/_subscription.html.erb_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "app/configurations/_subscription", type: :view do
+  let(:user) { create(:user, :gestor, company: company, active: true) }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  context "quando a empresa está no plano Starter" do
+    let(:starter_plan) { create(:plan, :starter) }
+    let(:company) { create(:company, plan: starter_plan, payment_method: "pix", active: true) }
+
+    before do
+      create(:subscription, company: company, subscription_plan: starter_plan, status: :active)
+    end
+
+    it "mostra cards dos planos pagos ativos com formas de pagamento" do
+      Plan.paid.update_all(status: "inactive")
+
+      basico = create(:plan, name: "Basico", reason: "Plano básico", transaction_amount: 99.0)
+      profissional = create(:plan, :profissional, max_technicians: 5, max_orders: 50, max_budgets: 20, support_level: "E-mail")
+      create(:plan, :starter)
+
+      render partial: "app/configurations/subscription"
+
+      aggregate_failures do
+        expect(rendered).to include("Planos pagos disponíveis")
+        expect(rendered).to include(basico.name)
+        expect(rendered).to include(basico.reason)
+        expect(rendered).to include(profissional.name)
+        expect(rendered).to include("paid-subscription-card")
+        expect(rendered).to include("Compare os planos e escolha uma opção para continuar.")
+        expect(rendered).not_to include("Formas de pagamento</div>")
+        expect(rendered).to include("PIX")
+        expect(rendered).to include("Cartão")
+        expect(rendered).to include("Boleto")
+        expect(rendered).to include("Escolher plano")
+        expect(rendered).to include("paidSubscriptionModal")
+        expect(rendered).to include("start_paid_subscription")
+        expect(rendered).to include('type="checkbox"')
+        expect(rendered).not_to include('type="radio"')
+        expect(rendered).not_to include("starter-gratuito")
+      end
+    end
+
+    it "mostra mensagem quando não há plano pago ativo" do
+      Plan.paid.update_all(status: "inactive")
+
+      render partial: "app/configurations/subscription"
+
+      expect(rendered).to include("Nenhum plano pago disponível no momento.")
+    end
+  end
+
+  context "quando a empresa está em um plano pago" do
+    let(:paid_plan) { create(:plan, :profissional) }
+    let(:company) { create(:company, plan: paid_plan, payment_method: "boleto", active: true) }
+
+    before do
+      create(:subscription, company: company, subscription_plan: paid_plan, status: :active)
+      create(:plan, :enterprise)
+    end
+
+    it "não mostra cards de adesão" do
+      render partial: "app/configurations/subscription"
+
+      aggregate_failures do
+        expect(rendered).not_to include("Planos pagos disponíveis")
+        expect(rendered).not_to include("Compare os planos")
+        expect(rendered).not_to include("paidSubscriptionModal")
+        expect(rendered).to include("Cancelamento")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Resumo

- Exibe cards de planos pagos para empresas no plano Starter dentro de Configurações > Assinatura.
- Permite iniciar adesão a um plano pago pelo modal, usando PIX, Boleto ou Cartão.
- Mantém a assinatura Starter ativa até a aprovação do pagamento e ativa a assinatura paga após confirmação do Mercado Pago.
- Registra auditoria do início da adesão em `audit_events`.

## Detalhes

- O modal reutiliza o fluxo de tokenização de cartão apenas quando Cartão é selecionado.
- PIX e Boleto disparam os jobs de criação de pagamento sem tentar tokenizar cartão.
- A seleção de forma de pagamento usa checkboxes com seleção exclusiva.
- Os cards têm interação visual com hover e clique no card inteiro.
- O fluxo cancela assinaturas pagas pendentes antigas antes de criar a nova pendência.

## Validação

- `bundle exec rspec spec/views/app/configurations spec/controllers/app/configurations_controller_spec.rb`
- `bundle exec rspec spec/controllers/app/configurations_controller_spec.rb spec/services/audit/action_catalog_spec.rb spec/models/audit_event_spec.rb`
- Suíte ampliada executada anteriormente: comandos de Mercado Pago, jobs de pagamento, models de empresa/assinatura e webhook processor.