### PR TITLE
ajuste no menu dropdown de suporte

### DIFF
--- a/.github/workflows/policy-window.yml
+++ b/.github/workflows/policy-window.yml
@@ -2,6 +2,12 @@ name: PR Window Policy
 
 on:
   pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
 
@@ -13,6 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: ruby bin/validate_pr_title "$PR_TITLE"
 
       - name: Evaluate change scope and allowed window
         env:

--- a/README_TECNICO.md
+++ b/README_TECNICO.md
@@ -587,6 +587,8 @@ A política de janela está em
 
 Regras implementadas:
 
+- título do PR não pode começar com marcador de IA, como `[codex]`, `[IA]`,
+  `Claude:`, `Copilot -`, etc.
 - mudanças sensíveis: somente `22:00-06:00` (America/Sao_Paulo)
 - mudanças simples: somente `09:00-18:00` (America/Sao_Paulo)
 - PR com migration deve conter apenas `db/migrate/*` e opcionalmente

--- a/app/views/layouts/partials/_sidebar.html.erb
+++ b/app/views/layouts/partials/_sidebar.html.erb
@@ -84,11 +84,46 @@
     </li>
 
     <% if can?(:read, :knowledge_base) %>
-    <li id="onboarding-tour-support-menu" class="list-group-item <%= active_menu_class(app_knowledge_base_index_path) %>">
-      <%= link_to app_knowledge_base_index_path do %>
-      <div class="parent-icon"><i class="bx bx-support"></i></div>
-      <div class="menu-title">Suporte</div>
-      <% end %>
+    <li id="onboarding-tour-support-menu" class="list-group-item <%= active_support_menu_class %>">
+      <a href="javascript:;" class="has-arrow">
+        <div class="parent-icon"><i class="bx bx-support"></i></div>
+        <div class="menu-title">Suporte</div>
+      </a>
+      <ul>
+        <% if current_user.company&.starter_plan? %>
+          <li>
+            <%= link_to app_knowledge_base_index_path do %>
+              <i class="bx bx-book-open"></i>Base de conhecimento
+            <% end %>
+          </li>
+        <% else %>
+          <li>
+            <%= link_to app_support_index_path do %>
+              <i class="bx bx-home-circle"></i>Visão geral
+            <% end %>
+          </li>
+          <li>
+            <%= link_to app_support_index_path(section: "tickets") do %>
+              <i class="bx bx-conversation"></i>Tickets
+            <% end %>
+          </li>
+          <li>
+            <%= link_to app_support_index_path(section: "knowledge_base") do %>
+              <i class="bx bx-book-open"></i>Base de conhecimento
+            <% end %>
+          </li>
+          <li>
+            <%= link_to app_support_index_path(section: "suggestions") do %>
+              <i class="bx bx-bulb"></i>Sugestões
+            <% end %>
+          </li>
+          <li>
+            <%= link_to app_support_index_path(section: "quick_contact") do %>
+              <i class="bx bx-envelope"></i>Contato rápido
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
     </li>
     <% end %>
     

--- a/bin/validate_pr_title
+++ b/bin/validate_pr_title
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../lib/pull_request_title_policy"
+
+title = ARGV.first || ENV["PR_TITLE"].to_s
+reason = PullRequestTitlePolicy.invalid_reason(title)
+
+if reason
+  warn reason
+  exit 1
+end
+
+puts "Título do PR válido."

--- a/lib/pull_request_title_policy.rb
+++ b/lib/pull_request_title_policy.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PullRequestTitlePolicy
+  AI_MARKERS = %w[
+    ai
+    ia
+    codex
+    copilot
+    claude
+    chatgpt
+    gpt
+    openai
+    gemini
+    cursor
+    aider
+    anthropic
+    perplexity
+  ].freeze
+
+  AI_MARKER_PATTERN = AI_MARKERS.map { |marker| Regexp.escape(marker) }.join("|")
+  BRACKETED_PREFIX_PATTERN = /\A\s*\[(?<marker>[^\]]+)\]/i
+  DIRECT_PREFIX_PATTERN = /\A\s*(?<marker>#{AI_MARKER_PATTERN})\s*(?::|-|–|—|\|)/i
+
+  module_function
+
+  def valid?(title)
+    invalid_reason(title).nil?
+  end
+
+  def invalid_reason(title)
+    title = title.to_s
+
+    if bracketed_ai_prefix?(title) || direct_ai_prefix?(title)
+      "O título do PR não pode começar com marcador de IA, como [codex], [IA] ou Claude:."
+    end
+  end
+
+  def bracketed_ai_prefix?(title)
+    match = title.match(BRACKETED_PREFIX_PATTERN)
+    return false unless match
+
+    match[:marker].match?(/\b(?:#{AI_MARKER_PATTERN})\b/i)
+  end
+
+  def direct_ai_prefix?(title)
+    title.match?(DIRECT_PREFIX_PATTERN)
+  end
+end

--- a/spec/requests/app/low_priority_controllers_spec.rb
+++ b/spec/requests/app/low_priority_controllers_spec.rb
@@ -110,18 +110,45 @@ RSpec.describe "Controllers App de prioridade baixa", type: :request do
     expect(response.body).to include(user.name)
   end
 
-  it "mostra Suporte como link direto para a base de conhecimento no menu" do
+  it "mostra Suporte como dropdown restrito à base de conhecimento no menu do plano Starter" do
+    plan.update!(free: true, transaction_amount: 0, support_level: "Base de conhecimento")
+
     get "/knowledge_base"
 
     aggregate_failures do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("onboarding-tour-support-menu")
+      expect(response.body).to include("has-arrow")
       expect(response.body).to include(%(href="/knowledge_base"))
-      expect(response.body).not_to include("Visão Geral")
+      expect(response.body).to include("Base de conhecimento")
+      expect(response.body).not_to include("Visão geral")
       expect(response.body).not_to include("Tickets")
       expect(response.body).not_to include("Sugestões")
-      expect(response.body).not_to include("Contato Rápido")
+      expect(response.body).not_to include("Contato rápido")
       expect(response.body).not_to include("Ver tour novamente")
+    end
+  end
+
+  it "mostra Suporte como dropdown com subitens completos no menu do plano Profissional" do
+    plan.update!(name: "Profissional", free: false, transaction_amount: 199, support_level: "prioritário")
+
+    get "/support"
+
+    aggregate_failures do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("onboarding-tour-support-menu")
+      expect(response.body).to include("has-arrow")
+      expect(response.body).to include(%(href="/support"))
+      expect(response.body).to include(%(href="/support?section=tickets"))
+      expect(response.body).to include(%(href="/support?section=knowledge_base"))
+      expect(response.body).to include(%(href="/support?section=suggestions"))
+      expect(response.body).to include(%(href="/support?section=quick_contact"))
+      expect(response.body).to include("Central de suporte")
+      expect(response.body).to include("Abrir novo ticket")
+      expect(response.body).to include("Visão geral")
+      expect(response.body).to include("Tickets")
+      expect(response.body).to include("Sugestões")
+      expect(response.body).to include("Contato rápido")
     end
   end
 

--- a/spec/services/pull_request_title_policy_spec.rb
+++ b/spec/services/pull_request_title_policy_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/pull_request_title_policy")
+
+RSpec.describe PullRequestTitlePolicy do
+  describe ".valid?" do
+    it "bloqueia títulos iniciados com [codex]" do
+      expect(described_class.valid?("[codex] Corrige menu de suporte")).to be(false)
+    end
+
+    it "bloqueia títulos iniciados com outros marcadores de IA entre colchetes" do
+      forbidden_titles = [
+        "[IA] Corrige menu de suporte",
+        "[AI] Corrige menu de suporte",
+        "[Claude] Corrige menu de suporte",
+        "[Copilot] Corrige menu de suporte",
+        "[ChatGPT] Corrige menu de suporte",
+        "[OpenAI] Corrige menu de suporte",
+        "[Gemini] Corrige menu de suporte"
+      ]
+
+      expect(forbidden_titles).to all(satisfy { |title| !described_class.valid?(title) })
+    end
+
+    it "bloqueia títulos iniciados com marcador textual de IA" do
+      forbidden_titles = [
+        "Codex: Corrige menu de suporte",
+        "IA - Corrige menu de suporte",
+        "AI | Corrige menu de suporte",
+        "Claude — Corrige menu de suporte"
+      ]
+
+      expect(forbidden_titles).to all(satisfy { |title| !described_class.valid?(title) })
+    end
+
+    it "permite títulos sem marcador de IA no início" do
+      allowed_titles = [
+        "Corrige menu de suporte",
+        "[suporte] Corrige dropdown do menu",
+        "Corrige integração de IA no relatório"
+      ]
+
+      expect(allowed_titles).to all(satisfy { |title| described_class.valid?(title) })
+    end
+  end
+
+  describe "GitHub Actions integration" do
+    it "mantém o validador conectado ao workflow de PR" do
+      workflow = Rails.root.join(".github/workflows/policy-window.yml").read
+
+      expect(workflow).to include("ruby bin/validate_pr_title")
+      expect(workflow).to include("- edited")
+    end
+  end
+end


### PR DESCRIPTION
## O que muda

Transforma o item **Suporte** do menu lateral, antes um link direto para a base de conhecimento, em um dropdown com subitens adequados ao plano da empresa:

- **Plano Starter**: dropdown restrito apenas à *Base de conhecimento*.
- **Demais planos**: dropdown completo com *Visão geral*, *Tickets*, *Base de conhecimento*, *Sugestões* e *Contato rápido*.

Também adiciona a tooling de política de título de PR (`lib/pull_request_title_policy.rb`, `bin/validate_pr_title` e o workflow `policy-window.yml`), que impede títulos de PR iniciados com marcadores de IA (ex.: `[codex]`, `Claude:`).

## Arquivos principais

- `app/views/layouts/partials/_sidebar.html.erb` — novo dropdown de Suporte.
- `spec/requests/app/low_priority_controllers_spec.rb` — cobre o comportamento por plano.
- `lib/pull_request_title_policy.rb` + `spec/services/pull_request_title_policy_spec.rb` — política de título de PR.

## Testes

- [ ] `bundle exec rspec spec/requests/app/low_priority_controllers_spec.rb spec/services/pull_request_title_policy_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
