### PR TITLE
Ajusta rótulos de tickets de suporte

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
       else "secondary"
       end
 
-    content_tag :span, ticket.status.humanize, class: "badge bg-#{status_class}"
+    content_tag :span, ticket.status_label, class: "badge bg-#{status_class}"
   end
 
   def ticket_impact_badge(ticket)
@@ -81,7 +81,7 @@ module ApplicationHelper
       end
 
     content_tag :span,
-                (ticket.impact&.humanize || "-"),
+                (ticket.impact.present? ? ticket.impact_label : "-"),
                 class: "badge bg-#{impact_class}"
   end
 

--- a/app/mailers/support_ticket_mailer.rb
+++ b/app/mailers/support_ticket_mailer.rb
@@ -26,7 +26,7 @@ class SupportTicketMailer < ApplicationMailer
 
     mail(
       to: recipient_emails,
-      subject: "[Ticket ##{@ticket.id}] Status atualizado para #{@ticket.status.humanize}"
+      subject: "[Ticket ##{@ticket.id}] Status atualizado para #{@ticket.status_label}"
     )
   end
 

--- a/app/models/support_ticket.rb
+++ b/app/models/support_ticket.rb
@@ -1,4 +1,35 @@
 class SupportTicket < ApplicationRecord
+  CATEGORY_LABELS = {
+    "duvida" => "Dúvida",
+    "problema_tecnico" => "Problema técnico",
+    "financeiro" => "Financeiro",
+    "sugestao" => "Sugestão",
+    "outros" => "Outros"
+  }.freeze
+
+  IMPACT_LABELS = {
+    "baixo" => "Baixo",
+    "medio" => "Médio",
+    "alto" => "Alto",
+    "bloqueante" => "Bloqueante"
+  }.freeze
+
+  STATUS_LABELS = {
+    "aberto" => "Aberto",
+    "em_andamento" => "Em andamento",
+    "aguardando_cliente" => "Aguardando cliente",
+    "resolvido" => "Resolvido",
+    "fechado" => "Fechado",
+    "cancelado" => "Cancelado"
+  }.freeze
+
+  PRIORITY_LABELS = {
+    "baixa" => "Baixa",
+    "normal" => "Normal",
+    "alta" => "Alta",
+    "critica" => "Crítica"
+  }.freeze
+
   belongs_to :company
   belongs_to :user
   belongs_to :order_service, optional: true
@@ -52,6 +83,54 @@ class SupportTicket < ApplicationRecord
 
   before_update :prevent_status_change_if_closed_or_cancelled
 
+  def self.category_label_for(value)
+    label_for(CATEGORY_LABELS, value)
+  end
+
+  def self.impact_label_for(value)
+    label_for(IMPACT_LABELS, value)
+  end
+
+  def self.status_label_for(value)
+    label_for(STATUS_LABELS, value)
+  end
+
+  def self.priority_label_for(value)
+    label_for(PRIORITY_LABELS, value)
+  end
+
+  def self.category_options
+    categories.keys.map { |category| [category_label_for(category), category] }
+  end
+
+  def self.impact_options
+    impacts.keys.map { |impact| [impact_label_for(impact), impact] }
+  end
+
+  def self.status_options
+    statuses.keys.map { |status| [status_label_for(status), status] }
+  end
+
+  def self.priority_options
+    priorities.keys.map { |priority| [priority_label_for(priority), priority] }
+  end
+
+  def category_label
+    self.class.category_label_for(category)
+  end
+
+  def impact_label
+    self.class.impact_label_for(impact)
+  end
+
+  def status_label
+    self.class.status_label_for(status)
+  end
+
+  def priority_label
+    self.class.priority_label_for(priority)
+  end
+
   def add_message!(user:, body:, attachments: [])
     raise "Ticket fechado ou cancelado não pode ser reaberto, caso necessário abra um novo ticket" if fechado? || cancelado?
 
@@ -77,6 +156,12 @@ class SupportTicket < ApplicationRecord
   def mark_as_closed!
     update!(status: :fechado)
   end
+
+  def self.label_for(labels, value)
+    value = value.to_s
+    labels.fetch(value, value.humanize)
+  end
+  private_class_method :label_for
 
   private
 

--- a/app/views/admin/tickets/index.html.erb
+++ b/app/views/admin/tickets/index.html.erb
@@ -20,14 +20,14 @@
                   <div class="col-md-3">
                     <label class="form-label">Status</label>
                     <%= select_tag :status,
-                                   options_for_select([["Todos", ""]] + SupportTicket.statuses.keys.map { |s| [s.humanize, s] }, params[:status]),
+                                   options_for_select([["Todos", ""]] + SupportTicket.status_options, params[:status]),
                                    class: "form-select" %>
                   </div>
 
                   <div class="col-md-3">
                     <label class="form-label">Categoria</label>
                     <%= select_tag :category,
-                                   options_for_select([["Todas", ""]] + SupportTicket.categories.keys.map { |c| [c.humanize, c] }, params[:category]),
+                                   options_for_select([["Todas", ""]] + SupportTicket.category_options, params[:category]),
                                    class: "form-select" %>
                   </div>
 
@@ -94,7 +94,7 @@
                         <td><%= ticket.company&.name %></td>
                         <td><%= ticket.user&.name %></td>
 
-                        <td><%= ticket.category.humanize %></td>
+                        <td><%= ticket.category_label %></td>
 
                         <td><%= ticket_status_badge(ticket) %></td>
 

--- a/app/views/admin/tickets/show.html.erb
+++ b/app/views/admin/tickets/show.html.erb
@@ -85,17 +85,17 @@
             <div class="row mb-3">
               <div class="col-md-4">
                 <strong>Categoria:</strong>
-                <p class="mb-0"><%= @ticket.category&.humanize || "-" %></p>
+                <p class="mb-0"><%= @ticket.category.present? ? @ticket.category_label : "-" %></p>
               </div>
 
               <div class="col-md-4">
                 <strong>Impacto:</strong>
-                <p class="mb-0"><%= @ticket.impact&.humanize || "-" %></p>
+                <p class="mb-0"><%= @ticket.impact.present? ? @ticket.impact_label : "-" %></p>
               </div>
 
               <div class="col-md-4">
                 <strong>Prioridade:</strong>
-                <p class="mb-0"><%= @ticket.priority&.humanize || "-" %></p>
+                <p class="mb-0"><%= @ticket.priority.present? ? @ticket.priority_label : "-" %></p>
               </div>
             </div>
 

--- a/app/views/app/support/_tickets.html.erb
+++ b/app/views/app/support/_tickets.html.erb
@@ -16,13 +16,13 @@
         <div class="col-md-4">
           <label class="form-label">Status</label>
           <%= select_tag :status,
-                         options_for_select([["Todos", ""]] + SupportTicket.statuses.keys.map { |s| [s.humanize, s] }, params[:status]),
+                         options_for_select([["Todos", ""]] + SupportTicket.status_options, params[:status]),
                          class: "form-select" %>
         </div>
         <div class="col-md-4">
           <label class="form-label">Categoria</label>
           <%= select_tag :category,
-                         options_for_select([["Todas", ""]] + SupportTicket.categories.keys.map { |c| [c.humanize, c] }, params[:category]),
+                         options_for_select([["Todas", ""]] + SupportTicket.category_options, params[:category]),
                          class: "form-select" %>
         </div>
         <div class="col-md-2">
@@ -68,7 +68,7 @@
                   <%= truncate(ticket.subject, length: 60) %>
                 <% end %>
               </td>
-              <td><%= ticket.category.humanize %></td>
+              <td><%= ticket.category_label %></td>
               <td><%= ticket_status_badge(ticket) %></td>
               <td><%= ticket_impact_badge(ticket) %></td>
               <td>

--- a/app/views/app/support_tickets/new.html.erb
+++ b/app/views/app/support_tickets/new.html.erb
@@ -23,21 +23,21 @@
                 <div class="col-md-4 mb-3">
                   <%= f.label :category, "Categoria", class: "form-label" %>
                   <%= f.select :category,
-                               SupportTicket.categories.keys.map { |c| [c.humanize, c] },
+                               SupportTicket.category_options,
                                { include_blank: "Selecione" },
                                class: "form-select" %>
                 </div>
                 <div class="col-md-4 mb-3">
                   <%= f.label :impact, "Impacto", class: "form-label" %>
                   <%= f.select :impact,
-                               SupportTicket.impacts.keys.map { |i| [i.humanize, i] },
+                               SupportTicket.impact_options,
                                { include_blank: "Selecione" },
                                class: "form-select" %>
                 </div>
                 <div class="col-md-4 mb-3">
                   <%= f.label :priority, "Prioridade", class: "form-label" %>
                   <%= f.select :priority,
-                               SupportTicket.priorities.keys.map { |p| [p.humanize, p] },
+                               SupportTicket.priority_options,
                                { include_blank: "Selecione" },
                                class: "form-select" %>
                 </div>

--- a/app/views/app/support_tickets/show.html.erb
+++ b/app/views/app/support_tickets/show.html.erb
@@ -23,7 +23,7 @@
               <div class="text-end">
                 <% if @support_ticket.status %>
                   <span class="badge bg-primary">
-                    <%= @support_ticket.status.humanize %>
+                    <%= @support_ticket.status_label %>
                   </span>
                 <% end %>
                 <% if @support_ticket.aberto? || @support_ticket.em_andamento? || @support_ticket.aguardando_cliente? || @support_ticket.resolvido? %>
@@ -40,15 +40,15 @@
             <div class="row text-muted small mb-3">
               <div class="col-md-3 mb-2">
                 <div class="fw-semibold text-dark">Categoria</div>
-                <div><%= @support_ticket.category&.humanize || "-" %></div>
+                <div><%= @support_ticket.category.present? ? @support_ticket.category_label : "-" %></div>
               </div>
               <div class="col-md-3 mb-2">
                 <div class="fw-semibold text-dark">Impacto</div>
-                <div><%= @support_ticket.impact&.humanize || "-" %></div>
+                <div><%= @support_ticket.impact.present? ? @support_ticket.impact_label : "-" %></div>
               </div>
               <div class="col-md-3 mb-2">
                 <div class="fw-semibold text-dark">Prioridade</div>
-                <div><%= @support_ticket.priority&.humanize || "-" %></div>
+                <div><%= @support_ticket.priority.present? ? @support_ticket.priority_label : "-" %></div>
               </div>
               <div class="col-md-3 mb-2">
                 <div class="fw-semibold text-dark">OS relacionada</div>

--- a/app/views/support_ticket_mailer/ticket_created.html.erb
+++ b/app/views/support_ticket_mailer/ticket_created.html.erb
@@ -9,10 +9,10 @@
   <strong>Ticket:</strong> #<%= @ticket.id %><br>
   <strong>Assunto:</strong> <%= @ticket.subject %><br>
   <strong>Solicitante:</strong> <%= @requester.full_name.presence || @requester.name %><br>
-  <strong>Categoria:</strong> <%= @ticket.category.humanize %><br>
-  <strong>Impacto:</strong> <%= @ticket.impact.humanize %><br>
-  <strong>Prioridade:</strong> <%= @ticket.priority.humanize %><br>
-  <strong>Status:</strong> <%= @ticket.status.humanize %>
+  <strong>Categoria:</strong> <%= @ticket.category_label %><br>
+  <strong>Impacto:</strong> <%= @ticket.impact_label %><br>
+  <strong>Prioridade:</strong> <%= @ticket.priority_label %><br>
+  <strong>Status:</strong> <%= @ticket.status_label %>
 </p>
 
 <p style="font-size:16px; line-height:1.6;">

--- a/app/views/support_ticket_mailer/ticket_created.text.erb
+++ b/app/views/support_ticket_mailer/ticket_created.text.erb
@@ -4,12 +4,12 @@ Empresa: <%= @company.name %>
 Ticket: #<%= @ticket.id %>
 Assunto: <%= @ticket.subject %>
 Solicitante: <%= @requester.full_name.presence || @requester.name %>
-Categoria: <%= @ticket.category.humanize %>
-Impacto: <%= @ticket.impact.humanize %>
-Prioridade: <%= @ticket.priority.humanize %>
-Status: <%= @ticket.status.humanize %>
+Categoria: <%= @ticket.category_label %>
+Impacto: <%= @ticket.impact_label %>
+Prioridade: <%= @ticket.priority_label %>
+Status: <%= @ticket.status_label %>
 
-Descricao:
+Descrição:
 <%= @ticket.description %>
 
 Abrir ticket:

--- a/app/views/support_ticket_mailer/ticket_status_changed.html.erb
+++ b/app/views/support_ticket_mailer/ticket_status_changed.html.erb
@@ -5,8 +5,8 @@
   <strong>Empresa:</strong> <%= @company.name %><br>
   <strong>Assunto:</strong> <%= @ticket.subject %><br>
   <strong>Responsável pela ação:</strong> <%= @actor.full_name.presence || @actor.name %><br>
-  <strong>Status anterior:</strong> <%= @previous_status.to_s.humanize %><br>
-  <strong>Novo status:</strong> <%= @ticket.status.humanize %>
+  <strong>Status anterior:</strong> <%= SupportTicket.status_label_for(@previous_status) %><br>
+  <strong>Novo status:</strong> <%= @ticket.status_label %>
 </p>
 
 <div style="margin:32px 0;">

--- a/app/views/support_ticket_mailer/ticket_status_changed.text.erb
+++ b/app/views/support_ticket_mailer/ticket_status_changed.text.erb
@@ -2,9 +2,9 @@ Status do ticket #<%= @ticket.id %> atualizado
 
 Empresa: <%= @company.name %>
 Assunto: <%= @ticket.subject %>
-Responsavel pela acao: <%= @actor.full_name.presence || @actor.name %>
-Status anterior: <%= @previous_status.to_s.humanize %>
-Novo status: <%= @ticket.status.humanize %>
+Responsável pela ação: <%= @actor.full_name.presence || @actor.name %>
+Status anterior: <%= SupportTicket.status_label_for(@previous_status) %>
+Novo status: <%= @ticket.status_label %>
 
 Ver ticket:
 <%= @ticket_url %>

--- a/app/views/support_ticket_mailer/ticket_updated.html.erb
+++ b/app/views/support_ticket_mailer/ticket_updated.html.erb
@@ -5,7 +5,7 @@
   <strong>Empresa:</strong> <%= @company.name %><br>
   <strong>Assunto:</strong> <%= @ticket.subject %><br>
   <strong>Autor da mensagem:</strong> <%= @actor.full_name.presence || @actor.name %><br>
-  <strong>Status atual:</strong> <%= @ticket.status.humanize %>
+  <strong>Status atual:</strong> <%= @ticket.status_label %>
 </p>
 
 <p style="font-size:16px; line-height:1.6;">

--- a/app/views/support_ticket_mailer/ticket_updated.text.erb
+++ b/app/views/support_ticket_mailer/ticket_updated.text.erb
@@ -3,7 +3,7 @@ Nova mensagem no ticket #<%= @ticket.id %>
 Empresa: <%= @company.name %>
 Assunto: <%= @ticket.subject %>
 Autor da mensagem: <%= @actor.full_name.presence || @actor.name %>
-Status atual: <%= @ticket.status.humanize %>
+Status atual: <%= @ticket.status_label %>
 
 Mensagem:
 <%= @support_message.body %>

--- a/spec/models/support_ticket_spec.rb
+++ b/spec/models/support_ticket_spec.rb
@@ -72,6 +72,70 @@ RSpec.describe SupportTicket, type: :model do
     end
   end
 
+  describe "labels dos enums" do
+    it "retorna categorias com acentuação correta" do
+      expect(described_class.category_options).to eq(
+        [
+          ["Dúvida", "duvida"],
+          ["Problema técnico", "problema_tecnico"],
+          ["Financeiro", "financeiro"],
+          ["Sugestão", "sugestao"],
+          ["Outros", "outros"]
+        ]
+      )
+    end
+
+    it "retorna impactos com acentuação correta" do
+      expect(described_class.impact_options).to eq(
+        [
+          ["Baixo", "baixo"],
+          ["Médio", "medio"],
+          ["Alto", "alto"],
+          ["Bloqueante", "bloqueante"]
+        ]
+      )
+    end
+
+    it "retorna status com rótulos legíveis" do
+      expect(described_class.status_options).to eq(
+        [
+          ["Aberto", "aberto"],
+          ["Em andamento", "em_andamento"],
+          ["Aguardando cliente", "aguardando_cliente"],
+          ["Resolvido", "resolvido"],
+          ["Fechado", "fechado"],
+          ["Cancelado", "cancelado"]
+        ]
+      )
+    end
+
+    it "retorna prioridades com acentuação correta" do
+      expect(described_class.priority_options).to eq(
+        [
+          ["Baixa", "baixa"],
+          ["Normal", "normal"],
+          ["Alta", "alta"],
+          ["Crítica", "critica"]
+        ]
+      )
+    end
+
+    it "expõe os labels no ticket" do
+      ticket = build(
+        :support_ticket,
+        category: :problema_tecnico,
+        impact: :medio,
+        status: :aguardando_cliente,
+        priority: :critica
+      )
+
+      expect(ticket.category_label).to eq("Problema técnico")
+      expect(ticket.impact_label).to eq("Médio")
+      expect(ticket.status_label).to eq("Aguardando cliente")
+      expect(ticket.priority_label).to eq("Crítica")
+    end
+  end
+
   describe "scopes" do
     describe ".recent" do
       it "ordena por última resposta e depois por criação" do


### PR DESCRIPTION
## Contexto
Os enums de tickets de suporte eram exibidos com `humanize`, gerando rótulos sem acentuação correta ou pouco legíveis, como `Problema tecnico`, `Medio`, `Critica` e `Aguardando cliente` dependente do formato bruto do enum.

## O que mudou
- Centraliza labels de categoria, impacto, status e prioridade em `SupportTicket`.
- Expõe helpers de model para opções de selects e exibição (`*_options`, `*_label` e `*_label_for`).
- Atualiza telas de tickets no admin e na área app para usar os labels padronizados.
- Atualiza badges, assuntos e templates de e-mail de suporte para usar os labels corretos.
- Corrige acentuação em textos dos e-mails texto de tickets.
- Adiciona specs cobrindo as opções e labels dos enums.

## Impacto
Usuários e admins passam a ver rótulos de tickets com português correto e consistente em listas, filtros, detalhes e notificações por e-mail, sem alterar os valores persistidos dos enums.

## Validação
- `env POSTGRES_PORT= REDIS_PORT= docker compose run --rm -e RAILS_ENV=test web bundle exec rspec spec/models/support_ticket_spec.rb`
- Resultado: `43 examples, 0 failures`