### PR TITLE
Atualiza documentação e cria documento de vendas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,7 @@ serviços técnicos.
 - Financeiro e relatórios: `docs/dev/ai/financeiro_e_relatorios.md`
 - Integrações e webhooks: `docs/dev/ai/integracoes_e_webhooks.md`
 - Auditoria e operação: `docs/dev/ai/auditoria_e_operacao.md`
+- API mobile: `docs/dev/ai/api_mobile.md`
+- Admin e backoffice: `docs/dev/ai/admin_backoffice.md`
+- Onboarding de usuários: `docs/dev/ai/onboarding.md`
+- Portal público do cliente: `docs/dev/ai/portal_cliente.md`

--- a/docs/dev/ai/00_indice.md
+++ b/docs/dev/ai/00_indice.md
@@ -25,3 +25,7 @@ alterar código.
 - [Financeiro e relatórios](financeiro_e_relatorios.md)
 - [Integrações e webhooks](integracoes_e_webhooks.md)
 - [Auditoria e operação](auditoria_e_operacao.md)
+- [API mobile](api_mobile.md)
+- [Admin e backoffice](admin_backoffice.md)
+- [Onboarding de usuários](onboarding.md)
+- [Portal público do cliente](portal_cliente.md)

--- a/docs/dev/ai/admin_backoffice.md
+++ b/docs/dev/ai/admin_backoffice.md
@@ -1,0 +1,172 @@
+# Admin Backoffice
+
+## Quando Ler Este Arquivo
+
+Leia antes de alterar qualquer tela ou controller do subdomínio `admin`:
+dashboard, empresas, usuários, assinaturas, reconciliação, planos, cupons,
+OS, tickets, base de conhecimento, logs, métricas, configurações ou coverage.
+
+## Visão Geral
+
+O backoffice administrativo roda no subdomínio `admin` e é a visão interna da
+plataforma. Ele é cross-tenant: consulta dados de todas as empresas, sem escopo
+por `company_id`. O acesso exige usuário com role `admin` — qualquer outro
+usuário é redirecionado para o subdomínio de login com alerta de acesso negado.
+
+Seções e finalidades:
+
+- Dashboard: indicadores globais (empresas ativas, assinaturas ativas, MRR
+  estimado, tickets abertos, novos cadastros no mês, OS finalizadas/atrasadas,
+  top empresas por OS, tickets recentes e assinaturas em atenção).
+- Empresas: listagem com busca e paginação; detalhe mostra tickets abertos.
+- Usuários: listagem com busca, filtro por role e detalhe.
+- Assinaturas: listagem e detalhe, somente leitura no controller.
+- Reconciliação de assinaturas: listagem e detalhe de
+  `SubscriptionReconciliationEvent`, somente leitura (`only: [:index, :show]`),
+  com filtros por busca, `result_status`, `source_job`, `divergent` e
+  `resolved`.
+- Planos: CRUD parcial (index, show, new, create, edit, update) de `Plan`.
+- Cupons: CRUD completo de `Coupon`, com filtros por busca, status e
+  `benefit_type`.
+- Ordens de serviço: listagem, detalhe com itens e geração de PDF via
+  `Cmd::Pdf::Create`.
+- Tickets: listagem com filtros (status, categoria, busca), detalhe com
+  mensagens e ação `resolve`.
+- Mensagens de suporte: criação de resposta em ticket (`only: [:create]`),
+  com anexos e notificação.
+- Base de conhecimento: CRUD de `KnowledgeBaseArticle` com filtros por
+  categoria, audiência e busca.
+- Logs: listagem e detalhe de `AuditEvent` com filtros e exportação CSV.
+- Métricas: status do Sentry, indicadores de erro por auditoria, filas do
+  Sidekiq e funil de onboarding/ativação.
+- Configurações: painel somente leitura de status de serviços e integrações,
+  mais edição do próprio perfil do admin.
+- Coverage: relatório de cobertura de testes, disponível apenas em
+  development.
+
+## Áreas Relacionadas
+
+- `docs/dev/ai/auditoria_e_operacao.md`: logs de auditoria e queries
+  operacionais consumidos pela tela de logs.
+- `docs/dev/ai/assinaturas.md`: assinaturas, planos e reconciliação exibidos
+  no admin.
+- `docs/dev/ai/suporte_e_base_conhecimento.md`: tickets, mensagens e artigos
+  gerenciados pelo admin.
+- `docs/dev/ai/financeiro_e_relatorios.md`: métricas globais da plataforma.
+- `docs/dev/ai/usuarios_e_permissoes.md`: role `admin` e regras de acesso.
+
+## Pontos De Entrada Importantes
+
+- `config/routes/admin.rb`
+- `app/controllers/admin_controller.rb`
+- `app/controllers/admin/dashboard_controller.rb`
+- `app/controllers/admin/companies_controller.rb`
+- `app/controllers/admin/users_controller.rb`
+- `app/controllers/admin/subscriptions_controller.rb`
+- `app/controllers/admin/subscription_reconciliation_events_controller.rb`
+- `app/controllers/admin/plans_controller.rb`
+- `app/controllers/admin/coupons_controller.rb`
+- `app/controllers/admin/order_services_controller.rb`
+- `app/controllers/admin/tickets_controller.rb`
+- `app/controllers/admin/support_messages_controller.rb`
+- `app/controllers/admin/knowledge_base_articles_controller.rb`
+- `app/controllers/admin/logs_controller.rb`
+- `app/controllers/admin/metrics_controller.rb`
+- `app/controllers/admin/configurations_controller.rb`
+- `app/controllers/admin/coverage_controller.rb`
+- `app/models/subscription_reconciliation_event.rb`
+
+## Regras De Negócio
+
+- Todo controller do admin herda de `AdminController`, que aplica
+  `require_admin` (`current_user&.admin?`) e `skip_authorization_check`;
+  a proteção vem do role, não do CanCan.
+- O admin é cross-tenant por design: as consultas não são escopadas por
+  empresa. Não adicionar escopo de tenant nem reutilizar essas queries em
+  áreas de gestor.
+- Planos: `plan_params` inclui limites (`max_technicians`, `max_orders`,
+  `max_budgets`), `support_level`, `transaction_amount` e flag `free`. Plano
+  pago deve ter `transaction_amount` positivo (validação em `Plan`). O plano
+  Starter é o plano com `free: true` (`Company#starter_plan?`) e assinaturas
+  de plano free não podem ser agendadas para cancelamento.
+- Cupons: `benefit_type` é `discount` ou `trial`; desconto usa `percentage`
+  ou `fixed_amount`; trial exige `trial_frequency` e `trial_frequency_type`.
+  O `new` já sugere `active`, `discount`, `percentage` e `first_cycle_only`.
+  Exclusão é bloqueada quando há resgates vinculados
+  (`ActiveRecord::DeleteRestrictionError`).
+- Tickets: admin não cria nem edita tickets (`only: [:index, :show]` mais
+  `resolve`). `resolve` usa `mark_as_resolved!` e dispara
+  `SupportTicketNotifications.notify_status_changed`. Respostas entram por
+  `Admin::SupportMessagesController#create` via `ticket.add_message!`, com
+  anexos e `notify_message`; erro de validação re-renderiza
+  `admin/tickets/show` com 422.
+- Reconciliação de assinaturas é somente leitura no admin: os eventos são
+  gerados por jobs (campo `source_job`) e a tela só lista e detalha.
+- Logs: filtros por busca (nome/e-mail do ator, `actor_id`, `request_id`,
+  `resource_id`), action, source, empresa e período (`occurred_at`).
+  Exportação CSV usa `Cmd::Exports::GenerateCsv` com template `:admin_logs`
+  e lotes de 1000. `per` só aceita 10, 20, 30 ou 50.
+- Métricas: períodos fixos de 24h, 7d e 30d. Indicadores de erro contam
+  `AuditEvent` das actions `job.failed`, `report.export.failed` e
+  `webhook.failed`. Sidekiq lê `ProcessSet`, fila `default`, retries e dead
+  set com fallback zerado em erro. Onboarding usa coorte de usuários
+  `admin`/`gestor` com empresa criados no período, medindo conclusão e
+  dismissal do onboarding, primeira OS em 24h, tempo médio até a primeira OS
+  e retenção D7 via eventos de auditoria. `test_sentry` envia exceção de
+  teste ao Sentry e audita `system.monitoring.test_triggered`.
+- Configurações: painel derivado de ENV e checagens em runtime (banco, Redis,
+  Sidekiq, Mercado Pago, webhook secret, SMTP). A única escrita é o perfil do
+  próprio admin (`id` fixo `"profile"`, permitindo `name`, `phone` e senha);
+  qualquer outro `id` retorna alerta de configuração não encontrada.
+- Coverage: rota e mount de `/coverage_report` só existem em development; o
+  controller lê `coverage/.last_run.json` e `coverage/.resultset.json`.
+
+## Estados E Transições
+
+- `SubscriptionReconciliationEvent` registra `local_status_before` e
+  `local_status_after` da assinatura, com `result_status` em `success` ou
+  `error`, além das flags `divergent` e `resolved` (scopes `recent`,
+  `divergent`, `errors`).
+- Ticket resolvido via `resolve` transita pelo `mark_as_resolved!` do
+  `SupportTicket`; o status anterior é preservado para a notificação.
+- Planos possuem `status` (`active`/`inactive`) e flag `free`; o Starter é o
+  plano free e não passa pelo fluxo de cancelamento de assinatura.
+- Cupons alternam `active`/inativo e diferem em comportamento por
+  `benefit_type` (`discount` zera parte do valor; `trial` zera o ciclo).
+
+## Riscos Comuns
+
+- Rota órfã: `resources :contents` em `config/routes/admin.rb` não possui
+  `Admin::ContentsController` correspondente — qualquer acesso a essas rotas
+  falha em runtime. Remover a rota ou criar o controller antes de referenciar
+  `admin_contents_*` em views.
+- `resources :plans`, `:companies`, `:users` e `:subscriptions` geram rotas
+  completas (incluindo `destroy`), mas os controllers implementam apenas
+  parte das actions; linkar rotas sem action implementada quebra em runtime.
+- Escopar consultas do admin por empresa por engano, ou reutilizar queries
+  cross-tenant do admin em telas de gestor (vazamento entre tenants).
+- Afrouxar `require_admin` ou reintroduzir authorization check sem regras,
+  já que os controllers usam `skip_authorization_check`.
+- Criar plano pago com `transaction_amount` zerado ou marcar plano errado
+  como `free`, mudando quem é tratado como Starter.
+- Excluir cupom com resgates: o controller trata
+  `DeleteRestrictionError`, mas mudanças na associação podem quebrar isso.
+- Transformar a tela de reconciliação em escrita — ela é somente leitura por
+  design.
+- Quebrar filtros ou o template CSV de logs (`:admin_logs`), usados em
+  investigação operacional.
+- Depender de Sidekiq/Redis nas métricas sem os fallbacks de erro existentes.
+
+## Testes Recomendados
+
+- Testes de acesso: usuário sem role admin redirecionado ao login em todos os
+  controllers do subdomínio.
+- Testes de filtros e paginação em empresas, usuários, tickets, cupons,
+  reconciliação e logs.
+- Testes de `resolve` de ticket e criação de mensagem com anexos, incluindo
+  notificações e re-render com 422.
+- Testes de CRUD de planos (validação de valor em plano pago) e de cupons
+  (discount vs trial, bloqueio de exclusão com resgates).
+- Testes de exportação CSV de logs e dos filtros por período.
+- Testes de métricas com coorte de onboarding e fallbacks de Sidekiq.
+- Teste de configurações restringindo escrita ao `id` `"profile"`.

--- a/docs/dev/ai/api_mobile.md
+++ b/docs/dev/ai/api_mobile.md
@@ -1,0 +1,132 @@
+# API Mobile
+
+## Quando Ler Este Arquivo
+
+Leia antes de alterar a API mobile (subdomínio `mobile`, namespace `/v1`),
+autenticação por token Bearer, sessões de API, payloads JSON, paginação,
+mapeamento de status ou anexos enviados pelo app.
+
+## Visão Geral
+
+A API mobile é uma API JSON servida sob o subdomínio `mobile` no caminho
+`/v1`, com controllers em `Mobile::V1` herdando de `ActionController::API`.
+A autenticação usa token Bearer opaco persistido em `MobileApiSession`
+(apenas o `token_digest` SHA-256 é armazenado). Todas as consultas de OS são
+escopadas à empresa do usuário e às OS em que ele é técnico atribuído.
+
+## Áreas Relacionadas
+
+- `config/routes/mobile.rb`: rotas sob `constraints subdomain: "mobile"`.
+- `MobileApiSession`: emissão, validação, expiração e revogação de tokens.
+- Auditoria: eventos `mobile.api.*` via `Audit::Log` com `source: "mobile"`
+  (valor válido em `AuditEvent::SOURCES`).
+- `OrderService`, `Budget`, `ServiceItem`, `Client`: dados expostos.
+
+## Pontos De Entrada Importantes
+
+- `config/routes/mobile.rb`
+- `app/controllers/mobile/v1/base_controller.rb`
+- `app/controllers/mobile/v1/auth_controller.rb`
+- `app/controllers/mobile/v1/health_controller.rb`
+- `app/controllers/mobile/v1/users_controller.rb`
+- `app/controllers/mobile/v1/dashboard_controller.rb`
+- `app/controllers/mobile/v1/agenda_controller.rb`
+- `app/controllers/mobile/v1/order_services_controller.rb`
+- `app/controllers/mobile/v1/budgets_controller.rb`
+- `app/models/mobile_api_session.rb`
+
+## Regras De Negócio
+
+- Endpoints e retornos:
+  - `GET /v1/health`: status do serviço, sem autenticação.
+  - `POST /v1/auth/login`: valida email/senha (Devise `valid_password?`),
+    exige usuário ativo e `access_enabled?`; retorna `accessToken`/`token`,
+    `token_type: "Bearer"`, `expires_at` e payload do usuário.
+  - `GET /v1/auth/me` e `GET /v1/users/me`: payload do usuário autenticado
+    (id, nome, email, telefone formatado, papel com rótulo pt-BR, iniciais,
+    empresa).
+  - `DELETE /v1/auth/logout`: revoga a sessão atual (`revoke!`).
+  - `DELETE /v1/auth/logout_all`: revoga todas as sessões ativas do usuário.
+  - `GET /v1/mobile/dashboard`: métricas (OS abertas, visitas hoje,
+    atrasadas, concluídas), próximas 5 visitas, breakdown por status e 5 OS
+    recentes.
+  - `GET /v1/mobile/agenda`: OS agendadas no intervalo `start_date`/`end_date`
+    (padrão: mês corrente), ordenadas por `scheduled_at`.
+  - OS: `index`/`show`/`update` disponíveis em duas rotas equivalentes,
+    `/v1/order_services` e `/v1/mobile/service_orders` (mesmo controller).
+    `index` aceita filtros `status` e `date` (ISO 8601) e é paginado;
+    `show`/`update` retornam payload detalhado (anexos, itens, financeiro).
+  - `GET /v1/budgets` e `GET /v1/budgets/:id`: orçamentos da empresa,
+    somente leitura, com filtro `status` validado contra `Budget.statuses`.
+- Ciclo de vida do token: emitido no login com TTL de 30 dias
+  (`end_of_day`), token bruto de 32 bytes hex retornado uma única vez; só o
+  SHA-256 (`token_digest`) é persistido. A cada requisição autenticada,
+  `last_used_at` é atualizado. Sessão é válida se `revoked_at` for nulo e
+  `expires_at` futuro (scope `active`).
+- Toda requisição autenticada revalida `user.active?` e
+  `user.access_enabled?`, além do token.
+- Escopo de dados: dashboard, agenda e OS usam
+  `mobile_company.order_services.by_technician(current_mobile_user.id)`,
+  ou seja, sempre limitados à empresa do usuário e às OS em que ele está
+  atribuído como técnico — não há tratamento diferenciado por papel
+  (gestor/admin também só veem OS às quais estão atribuídos). Orçamentos
+  são escopados apenas por empresa (`mobile_company.budgets`), sem filtro
+  por atribuição.
+- `order_services#update` permite apenas `status`, `notes`/`observations`
+  (ambos gravam em `observations`) e `attachments` (anexados via Active
+  Storage após o save).
+- i18n de status: a API expõe `status` (chave em inglês, ex.
+  `in_progress`), `statusKey` (enum interno, ex. `em_andamento`) e
+  `statusLabel` (rótulo pt-BR). Filtros de entrada aceitam ambas as formas
+  via `normalize_mobile_status` (remove acentos e normaliza).
+- Paginação: `page`/`per` (padrão 20, máximo 100), resposta com `data` e
+  `meta` (`current_page`, `total_pages`, `total_count`, `per_page`).
+- Auditoria: `with_mobile_current_context` define `Current.source =
+  "mobile"`; login/logout usam `Audit::AuthLogger` e demais ações registram
+  eventos `mobile.api.*` (listagem, visualização, atualização).
+- Valores monetários são expostos em centavos (`*Cents`) e como rótulo
+  formatado `R$ x,yy`.
+
+## Estados E Transições
+
+- `MobileApiSession`: ativa (sem `revoked_at`, `expires_at` futuro) →
+  revogada (logout/logout_all) ou expirada (TTL de 30 dias).
+- Status de OS seguem o enum de `OrderService` (`pendente`, `agendada`,
+  `em_andamento`, `concluida`, `finalizada`, `cancelada`, `atrasada`),
+  traduzidos para chaves em inglês no payload.
+- Prioridade no payload é derivada: `Alta` se atrasada, `Média` se agendada
+  para até 1 dia, senão `Normal`.
+- Erros de autenticação: 401 (token ausente/inválido/expirado, credenciais
+  inválidas), 403 (usuário inativo ou empresa com acesso desativado),
+  404 JSON para registro não encontrado, 422 para falha de validação no
+  update.
+
+## Riscos Comuns
+
+- Vazar o token bruto em logs — só o digest deve ser persistido.
+- Esquecer de revalidar `active?`/`access_enabled?` ao mudar autenticação.
+- Quebrar o escopo `by_technician` ou o escopo por empresa e expor OS de
+  outra empresa ou de outro técnico.
+- Divergência entre `mobile_status_key`/`mobile_status_label`/
+  `normalize_mobile_status` ao adicionar novo status de OS.
+- Alterar uma das duas rotas de OS (`order_services` vs
+  `mobile/service_orders`) e esquecer a outra — ambas usam o mesmo
+  controller.
+- Permitir campos extras no `update` sem revisar `params.permit`.
+- Esquecer `Current.source = "mobile"` e registrar auditoria com source
+  errado.
+
+## Testes Recomendados
+
+- Testes de request para login (sucesso, credenciais inválidas, usuário
+  inativo, empresa desativada) e ciclo do token (expiração, revogação,
+  logout_all). Hoje não existem specs para `mobile` em `spec/` — criar ao
+  alterar a API.
+- Testes de escopo: técnico de outra empresa ou não atribuído não acessa a
+  OS; orçamentos limitados à empresa.
+- Testes de `order_services#update` com status em inglês/português, notas e
+  anexos.
+- Testes de paginação (`page`/`per`, limite de 100) e filtros
+  (`status`, `date`, `start_date`/`end_date`).
+- Testes de auditoria verificando eventos `mobile.api.*` com
+  `source: "mobile"`.

--- a/docs/dev/ai/assinaturas.md
+++ b/docs/dev/ai/assinaturas.md
@@ -3,8 +3,8 @@
 ## Quando Ler Este Arquivo
 
 Leia antes de alterar assinatura, plano, cobrança, cupons, webhooks de pagamento,
-reconciliação, acesso da empresa por status comercial ou qualquer fluxo ligado
-ao Mercado Pago.
+reconciliação, acesso da empresa por status comercial, limites de plano,
+plano Starter gratuito ou qualquer fluxo ligado ao Mercado Pago.
 
 ## Visão Geral
 
@@ -12,18 +12,28 @@ ao Mercado Pago.
 depende da assinatura ativa, e mudanças nesse domínio podem afetar login,
 onboarding, limites de plano, faturamento, auditoria e jobs de reconciliação.
 
+`Plan` possui a flag `free`: existe um plano Starter gratuito (sem cobrança)
+além dos planos pagos. Empresas no Starter fazem upgrade para plano pago pela
+própria tela de configurações (`start_paid_subscription`), sem passar pelo
+fluxo de cadastro.
+
 ## Áreas Relacionadas
 
-- `register`: criação de empresa e assinatura inicial.
-- `app/gestor`: consulta de assinatura e acesso operacional.
+- `register`: criação de empresa e assinatura inicial (inclusive no Starter).
+- `app/gestor`: consulta de assinatura, upgrade a partir do Starter,
+  cancelamento agendado e acesso operacional.
 - `admin`: gestão de planos, assinaturas, empresas e reconciliação.
 - `webhook`: callbacks do Mercado Pago.
-- Jobs e services: ciclos de cobrança, expiração, cancelamento e reconciliação.
+- `suporte`: nível de suporte depende do plano; o Starter é restrito à base de
+  conhecimento.
+- Jobs e services: ciclos de cobrança, expiração, cancelamento e reconciliação
+  (todos escopados a planos pagos via scope `paid_plan`).
 
 ## Pontos De Entrada Importantes
 
 - `app/models/subscription.rb`
 - `app/models/plan.rb`
+- `app/models/company.rb` (`starter_plan?`, limites e `pdf_customization_available?`)
 - `app/models/coupon.rb`
 - `app/models/coupon_redemption.rb`
 - `app/models/subscription_reconciliation_event.rb`
@@ -31,33 +41,107 @@ onboarding, limites de plano, faturamento, auditoria e jobs de reconciliação.
 - `app/services/mercado_pago/webhook_processor.rb`
 - `app/services/coupons/redeem.rb`
 - `app/services/coupons/signup_benefit_resolver.rb`
+- `app/controllers/app/configurations_controller.rb` (`start_paid_subscription`,
+  `cancel_subscription`, `resume_subscription`)
 - `app/controllers/admin/subscriptions_controller.rb`
 - `app/controllers/web_hook/mercado_pago_controller.rb`
 
 ## Regras De Negócio
+
+### Planos e limites
+
+- `Plan#free?` marca o plano gratuito (Starter); `Plan.paid` retorna somente
+  planos com `free: false`. Plano pago exige `transaction_amount` positivo
+  (validação `paid_plan_must_have_positive_amount`).
+- Limites por plano: `max_technicians`, `max_orders`, `max_budgets` e
+  `support_level`. Valor `nil` significa ilimitado.
+- `Company#can_add_technician?` compara técnicos ativos com `max_technicians`.
+  `can_create_order?` e `can_create_budget?` contam registros criados no mês
+  corrente (a partir de `beginning_of_month`).
+- `Company#starter_plan?` verifica `free?` no plano atual (`current_plan` ou
+  `plan`). No Starter: não é possível adicionar técnicos (o gestor atua como
+  técnico), tickets de suporte são bloqueados (validação em `SupportTicket`) e
+  as seções de suporte redirecionam para a base de conhecimento.
+- Personalização de PDF (`pdf_customization_available?`) só existe nos planos
+  listados em `Company::PDF_CUSTOMIZATION_PLAN_NAMES` (Profissional e
+  Enterprise) — a checagem é por nome do plano.
+
+### Assinaturas
 
 - Somente assinatura `active` concede acesso comercial via `allows_access?`.
 - `Subscription` pertence a `Company`; qualquer consulta em área operacional
   deve preservar o escopo da empresa.
 - `Plan` se relaciona com `Subscription` por `external_id` e
   `preapproval_plan_id`, não por `plans.id`.
-- Upgrade de plano não permite downgrade nem troca para o mesmo nível no fluxo
-  atual.
+- Assinatura de plano gratuito tem `end_date` sempre nulo
+  (`clear_end_date_for_free_plan`, `before_validation`): não há ciclo de
+  cobrança nem expiração.
+- Os scopes de ciclo de vida de cobrança (`overdue_for_notification`,
+  `overdue_for_expiration`, `ready_to_cycle`) usam o scope `paid_plan` e nunca
+  alcançam o Starter.
 - Cancelamento agendado só vale para assinatura ativa e usa
   `cancel_at_period_end`, `cancel_requested_at` e `cancel_effective_on`.
+  `schedule_cancellation!` levanta erro para plano gratuito ("O plano Starter
+  não possui cancelamento de assinatura"); a UI de configurações também não
+  exibe o bloco de cancelamento no Starter.
 - Reativar renovação só é válido quando existe cancelamento agendado.
-- Cupons aplicados ficam em `CouponRedemption` e há unicidade por assinatura.
+- Upgrade de plano (`upgrade_to_plan!`) usa `PLAN_UPGRADE_RANKS`
+  (Basico → Profissional → Enterprise) e não permite downgrade nem troca para
+  o mesmo nível.
 - Alterações de status ou dados comerciais devem preservar auditoria.
+
+### Upgrade a partir do Starter (`start_paid_subscription`)
+
+- Disponível apenas quando a assinatura ativa atual é de plano gratuito
+  (`current_active_subscription&.free_plan?`); planos pagos usam o fluxo de
+  upgrade/cancelamento existente.
+- Exige plano pago ativo (`Plan.paid.where(status: :active)`) e forma de
+  pagamento válida (`Company::PAYMENT_METHODS`: `pix`, `credit_card`,
+  `boleto`). Cartão exige `card_token`.
+- Cria assinatura `pending` para o plano escolhido, cancela outras pendências
+  de planos diferentes e atualiza `payment_method` da empresa. A assinatura
+  Starter ativa permanece até a confirmação do pagamento.
+- Pagamento: boleto e PIX disparam jobs (`CreateUser::BoletoPaymentJob`,
+  `CreateUser::PixPaymentJob`); cartão chama
+  `Cmd::MercadoPago::CreateCreditCardPayment` de forma síncrona. Falha no
+  início do pagamento cancela a assinatura pendente.
+- Gera auditoria `subscription.paid_signup.started`.
+- `activate_as_current!` ativa a nova assinatura, cancela as demais ativas da
+  empresa e atualiza `company.plan`.
+
+### Cupons
+
+- `Coupon#benefit_type`: `discount` (percentual ou valor fixo) ou `trial`
+  (período gratuito com `trial_frequency` + `trial_frequency_type`).
+- Cupom de desconto exige `discount_type` e `discount_value`; cupom trial não
+  pode ter desconto financeiro e exige duração do teste.
+- Disponibilidade: `active`, janela `valid_from`/`valid_until` e
+  `max_redemptions` (contador `redemptions_count`).
+- Resgate (`CouponRedemption`): único por assinatura (`subscription_id`
+  unique) e no máximo um cupom por empresa a cada 12 meses
+  (`used_by_company_within_last_year?`).
+- `Coupons::SignupBenefitResolver` valida o cupom no signup: desconto que
+  zera o valor deve ser cadastrado como trial; cupom de desconto não é
+  suportado com cartão de crédito nesse fluxo; rejeições geram auditoria
+  `coupon.rejected`.
+- `Coupons::Redeem` registra o resgate com valores original, desconto e final.
 
 ## Estados E Transições
 
 - Status conhecidos: `pending`, `active`, `cancelled`, `expired`.
 - `activate_for!` define período, limpa cancelamento e expiração.
+- `activate_as_current!` ativa e cancela as outras assinaturas ativas da
+  empresa, sincronizando `company.plan`.
 - `cancel!` cancela imediatamente.
 - `expire!` marca expiração.
-- `schedule_cancellation!` agenda cancelamento no fim do período.
+- `schedule_cancellation!` agenda cancelamento no fim do período (bloqueado
+  para plano gratuito).
 - `resume_cancellation!` remove o cancelamento agendado.
 - `finalize_scheduled_cancellation!` efetiva cancelamento quando a data vence.
+- Mudança de `status` dispara `sync_company_access`: ativa ou desativa a
+  empresa e seus usuários.
+- Starter: assinatura `active` sem `end_date`, sem renovação e sem
+  cancelamento; a saída do Starter acontece via `start_paid_subscription`.
 
 ## Riscos Comuns
 
@@ -65,13 +149,29 @@ onboarding, limites de plano, faturamento, auditoria e jobs de reconciliação.
 - Ignorar `company_id` em consultas administrativas reaproveitadas na área `app`.
 - Confundir id interno de plano com ids externos do Mercado Pago.
 - Alterar status sem manter campos auxiliares coerentes.
+- Tratar `end_date` como sempre presente: no Starter ele é nulo. Jobs e
+  queries de cobrança devem usar o scope `paid_plan` para não processar o
+  plano gratuito.
+- Permitir cancelamento, expiração ou cobrança de assinatura de plano
+  gratuito.
+- Esquecer que limites `nil` significam ilimitado ao validar
+  `max_technicians`/`max_orders`/`max_budgets`.
+- Checar personalização de PDF por flag em vez de
+  `pdf_customization_available?` (a regra é por nome de plano).
 - Duplicar pagamento ou processar webhook repetido sem idempotência.
 - Remover registros com cupons ou reconciliações sem considerar dependências.
 
 ## Testes Recomendados
 
 - Testes de model para `Subscription`, `Plan`, `Coupon` e `CouponRedemption`.
+- Testes de `end_date` nulo e bloqueio de cancelamento em assinatura de plano
+  gratuito.
 - Testes de services em `MercadoPago::Subscriptions`, webhook processor e cupons.
+- Testes de `App::ConfigurationsController#start_paid_subscription`
+  (autorização, plano pago ativo, formas de pagamento, falha de pagamento).
+- Testes de limites de plano em `Company` (`can_add_technician?`,
+  `can_create_order?`, `can_create_budget?`) e de restrições do Starter
+  (suporte e técnicos).
 - Testes de controllers de assinatura em `admin`, `register` e `webhook`.
 - Testes de acesso quando status muda entre `pending`, `active`, `cancelled` e
   `expired`.

--- a/docs/dev/ai/onboarding.md
+++ b/docs/dev/ai/onboarding.md
@@ -1,0 +1,92 @@
+# Onboarding
+
+## Quando Ler Este Arquivo
+
+Leia antes de alterar o checklist de primeiros passos, o modal de boas-vindas
+do dashboard, o tracking automático de etapas ou as métricas de ativação e
+retenção no admin.
+
+## Visão Geral
+
+`UserOnboardingProgress` registra, por usuário, o progresso nas etapas de
+primeiros passos (técnico, cliente, orçamento, primeira OS, mudança de status
+e relatórios). O dashboard exibe modal de boas-vindas e checklist, os
+controllers marcam etapas automaticamente e o admin acompanha ativação e
+retenção D7.
+
+## Áreas Relacionadas
+
+- `app/gestor`: modal de boas-vindas, checklist e tour no dashboard.
+- Controllers operacionais: marcam etapas via `OnboardingTracking`.
+- `admin`: métricas de ativação, conclusão, dismiss e retenção D7.
+
+## Pontos De Entrada Importantes
+
+- `app/models/user_onboarding_progress.rb`
+- `app/controllers/app/onboarding_progress_controller.rb`
+- `app/controllers/concerns/onboarding_tracking.rb`
+- `app/controllers/app/dashboard_controller.rb`
+- `app/views/app/dashboard/_onboarding_welcome_modal.html.erb`
+- `app/views/app/dashboard/_onboarding_checklist.html.erb`
+- `app/views/app/dashboard/_onboarding_tour.html.erb`
+- `app/controllers/admin/metrics_controller.rb`
+
+## Regras De Negócio
+
+- `STEP_KEYS` define as 6 etapas válidas: `created_technician`,
+  `created_customer`, `created_budget`, `created_first_work_order`,
+  `moved_work_order_status`, `viewed_reports`.
+- Um registro de progresso por usuário (`user_id` único); o endpoint JSON usa
+  `find_or_create_by!`.
+- `completed_steps` é normalizado antes da validação: chaves fora de
+  `STEP_KEYS` são descartadas e valores viram booleanos estritos.
+- `progress_percentage` é a razão entre etapas concluídas e o total de
+  `STEP_KEYS`, arredondada.
+- `complete_step!` marca a etapa, atualiza `last_seen_step`, preenche
+  `finished_at` quando todas as etapas estão completas e retorna se a etapa
+  era inédita. Chave inválida levanta `ArgumentError`.
+- O endpoint `App::OnboardingProgressController` (show/update JSON) aceita
+  apenas as operações `complete_step`, `dismiss`, `resume`, `finish` e
+  `set_last_seen`; `complete_step` e `set_last_seen` exigem `step_key`.
+- `OnboardingTracking#mark_onboarding_step` é best-effort: falhas são apenas
+  logadas (warn) e não quebram a ação principal do controller.
+- Etapas são marcadas nos controllers: técnico criado, cliente criado,
+  orçamento criado, aprovação de orçamento (primeira OS), mudança de status
+  de OS e visualização de relatórios.
+- O modal de boas-vindas só aparece para usuário sem progresso ou com
+  progresso "zerado" (sem dismiss, sem finish, sem `last_seen_step` e sem
+  etapas concluídas); o checklist é exibido para não técnicos.
+- Métricas do admin usam coorte de usuários `admin`/`gestor` com empresa,
+  criados no período selecionado (24h/7d/30d): taxa de conclusão, taxa de
+  dismiss, primeira OS em até 24h, tempo médio até a primeira OS e retenção
+  D7 (algum `AuditEvent` do usuário entre o 7º e o 8º dia após o cadastro).
+
+## Estados E Transições
+
+- O progresso não usa enum: o estado deriva de `completed_steps`,
+  `dismissed_at`, `finished_at` e `last_seen_step`.
+- `dismiss!` preenche `dismissed_at`; `resume!` limpa; `finish!` preenche
+  `finished_at`; `complete_step!` pode finalizar automaticamente quando
+  `finished_all_steps?` é verdadeiro.
+
+## Riscos Comuns
+
+- Adicionar etapa nova sem atualizar `STEP_KEYS`, o checklist do dashboard e
+  as métricas de conclusão.
+- Aceitar `step_key` fora de `STEP_KEYS` (o model levanta `ArgumentError`).
+- Fazer o tracking de onboarding quebrar a ação principal (deve permanecer
+  best-effort, com rescue e log).
+- Reexibir o modal de boas-vindas para usuário que já dispensou, finalizou ou
+  progrediu no checklist.
+- Alterar a coorte ou a janela D7 das métricas do admin sem revisar as taxas
+  exibidas.
+
+## Testes Recomendados
+
+- Testes de model para `complete_step!`, normalização de `completed_steps`,
+  percentual e finalização automática.
+- Testes de request do endpoint JSON (show/update) cobrindo operações válidas,
+  inválidas e `step_key` ausente.
+- Testes dos controllers que marcam etapas via `mark_onboarding_step`.
+- Testes de elegibilidade do modal de boas-vindas no dashboard.
+- Testes das métricas de onboarding no admin (coorte, conclusão, D7).

--- a/docs/dev/ai/portal_cliente.md
+++ b/docs/dev/ai/portal_cliente.md
@@ -1,0 +1,90 @@
+# Portal do Cliente
+
+## Quando Ler Este Arquivo
+
+Leia antes de alterar o fluxo público de aprovação de orçamento pelo cliente
+final: rotas do subdomínio `cliente`, acesso por token, aprovação, rejeição,
+PDF ou e-mails relacionados.
+
+## Visão Geral
+
+O portal do cliente é a área pública, no subdomínio `cliente`, onde o cliente
+final acessa um orçamento por link assinado (token), revisa itens e valores,
+baixa o PDF e aprova ou rejeita. A aprovação cria a OS automaticamente e
+notifica os gestores por e-mail.
+
+## Áreas Relacionadas
+
+- `app/gestor`: envia o orçamento para aprovação e gera o token.
+- `cliente`: página pública de aprovação/rejeição e download de PDF.
+- Orçamentos e OS: aprovação converte o orçamento em ordem de serviço.
+- Mailers: entrega do link ao cliente e notificação de OS criada ao gestor.
+
+## Pontos De Entrada Importantes
+
+- `config/routes/cliente.rb`
+- `app/controllers/cliente/budget_approvals_controller.rb`
+- `app/views/cliente/budget_approvals/show.html.erb`
+- `app/models/budget.rb`
+- `app/commands/cmd/budgets/approve_and_create_order_service.rb`
+- `app/mailers/budget_mailer.rb`
+
+## Regras De Negócio
+
+- As rotas exigem subdomínio `cliente` e carregam o orçamento pelo `:token`
+  na URL: `show`, `generate_pdf` (GET) e `approve`, `reject` (PATCH).
+- O controller pula autenticação, checagem de autorização, bloqueio de
+  empresa inativa e aceite de termos; usa layout `public`.
+- O token é um `signed_id` com propósito `:budget_approval` e expiração
+  (por padrão o fim do dia de `valid_until` ou 1 semana). Token inválido ou
+  expirado retorna 404 com "Link inválido ou expirado."
+- `send_for_approval` (gestor) só ocorre para orçamento `rascunho` ou
+  `rejeitado`, tem throttle de 5 minutos e envia
+  `BudgetMailer.approval_request_to_client` com a URL de aprovação no
+  subdomínio `cliente`.
+- Aprovar chama `approve_and_create_order_service!(approver_role: :cliente)`;
+  se `approved_at` já está preenchido, apenas redireciona com aviso de que já
+  foi aprovado.
+- `Cmd::Budgets::ApproveAndCreateOrderService` roda com `with_lock`, é
+  idempotente (retorna a OS existente se o orçamento já tem
+  `order_service_id`), marca o orçamento como `aprovado`, cria a OS com
+  status `pendente` copiando os itens de serviço, garante auditoria de
+  `order_service.created` e notifica os gestores por e-mail
+  (`notify_manager_order_service_created`), com fallback para o responsável
+  da empresa.
+- Rejeitar exige motivo (`rejection_reason` não pode ficar em branco) e marca
+  `rejeitado` com `rejected_at`; se `rejected_at` já está preenchido, apenas
+  redireciona com aviso.
+- `generate_pdf` gera o PDF via `Cmd::Pdf::CreateBudget` e envia como
+  download `orcamento_<code>.pdf`.
+
+## Estados E Transições
+
+- `Budget.statuses`: `rascunho`, `enviado`, `aprovado`, `rejeitado`,
+  `cancelado`.
+- Aprovação é permitida a partir de `rascunho`, `enviado`, `rejeitado` ou
+  `aprovado`; rejeição a partir de `rascunho`, `enviado` ou `rejeitado`.
+- `send_for_approval!` muda para `enviado` e limpa `approved_at`,
+  `rejected_at` e `rejection_reason`.
+- A view pública decide o que mostrar por `approved_at`/`rejected_at`: alerta
+  de já aprovado, alerta de rejeitado (com motivo) ou os botões de resposta.
+
+## Riscos Comuns
+
+- Quebrar links já enviados ao mudar propósito, expiração ou lookup do token.
+- Reintroduzir autenticação/autorização nas rotas públicas e derrubar o fluxo
+  externo.
+- Permitir que um orçamento gere mais de uma OS (o comando usa lock e
+  idempotência por `order_service_id`).
+- Gerar URLs sem o subdomínio `cliente` em redirects, mailer ou views.
+- Vazar dados de outra empresa na página pública (o token dá acesso apenas ao
+  orçamento assinado).
+
+## Testes Recomendados
+
+- Testes de request do fluxo público: show, PDF, aprovação e rejeição com
+  token válido, inválido e expirado.
+- Testes de idempotência: aprovar duas vezes não cria segunda OS.
+- Testes de rejeição sem motivo (deve falhar) e com motivo.
+- Testes do mailer: link de aprovação ao cliente e notificação de OS criada
+  aos gestores (com fallback para o responsável).

--- a/docs/gestor/00_indice.md
+++ b/docs/gestor/00_indice.md
@@ -37,6 +37,7 @@ Este guia cobre as funcionalidades do perfil **gestor** no ambiente `app`.
 - [Como criar um orçamento](orcamentos/como_criar_orcamento.md)
 - [Como enviar orçamento para aprovação](orcamentos/como_enviar_orcamento_para_aprovacao.md)
 - [Como aprovar ou rejeitar orçamento (gestor)](orcamentos/como_aprovar_ou_rejeitar_orcamento.md)
+- [Como o cliente aprova o orçamento (portal do cliente)](orcamentos/como_cliente_aprova_orcamento.md)
 - [Como tratar orçamento rejeitado](orcamentos/como_tratar_orcamento_rejeitado.md)
 
 ## Clientes
@@ -60,6 +61,7 @@ Este guia cobre as funcionalidades do perfil **gestor** no ambiente `app`.
 
 ## Relatórios
 - [Como visualizar relatórios (OS e Orçamentos)](relatorios/como_ver_relatorios_os.md)
+- [Como exportar relatórios](relatorios/como_exportar_relatorios.md)
 
 ## Conta, Empresa e Assinatura
 - [Como atualizar seu perfil](conta/como_atualizar_perfil.md)
@@ -67,6 +69,8 @@ Este guia cobre as funcionalidades do perfil **gestor** no ambiente `app`.
 - [Como configurar regras de Ordens de Serviço](conta/como_configurar_regras_os.md)
 - [Como promover técnico para gestor](conta/como_promover_tecnico_a_gestor.md)
 - [Como consultar a assinatura](conta/como_gerenciar_assinatura.md)
+- [Como fazer upgrade de plano](conta/como_fazer_upgrade_de_plano.md)
+- [Como personalizar o PDF de OS e orçamentos](conta/como_personalizar_pdf.md)
 - [Como aceitar o contrato de utilização](conta/como_aceitar_termos.md)
 
 ## Suporte

--- a/docs/gestor/conta/como_fazer_upgrade_de_plano.md
+++ b/docs/gestor/conta/como_fazer_upgrade_de_plano.md
@@ -1,0 +1,32 @@
+# Como fazer upgrade de plano
+
+## Quando usar
+Quando sua empresa está no plano **Starter (gratuito)** e você precisa de mais técnicos, mais ordens de serviço e orçamentos por mês, personalização de PDF ou um nível de suporte melhor.
+
+## Pré-requisitos
+- Estar no plano Starter (a adesão pela tela de configurações está disponível apenas para o plano Starter).
+- Ter permissão para gerenciar a assinatura da empresa.
+
+## Passo a passo
+1. Acesse **Configurações** > **Assinatura**.
+2. Em **Planos pagos disponíveis**, compare os cartões: cada plano mostra o valor mensal e os limites de técnicos, ordens, orçamentos e o tipo de suporte.
+3. Clique em **Escolher plano** no plano desejado.
+4. Na janela **Adesão ao plano pago**, selecione a forma de pagamento: **PIX**, **Cartão** ou **Boleto**.
+5. Se escolher **Cartão**, preencha os dados do cartão (nome impresso, CPF do titular, número, validade e CVV). Os dados são tokenizados com segurança pelo Mercado Pago.
+6. Clique em **Continuar**.
+
+## O que acontece depois
+- **Cartão**: a assinatura será ativada após a aprovação do pagamento.
+- **PIX**: as instruções de pagamento são enviadas para o e-mail da empresa.
+- **Boleto**: o boleto é enviado para o e-mail da empresa.
+- A nova assinatura fica **pendente** até a confirmação do pagamento; enquanto isso, seu acesso continua normal pelo plano Starter.
+- Após a confirmação, o plano pago passa a valer e os novos limites são aplicados.
+
+## Erros comuns
+- Não selecionar a forma de pagamento antes de continuar.
+- Escolher cartão e deixar dados do cartão incompletos ou inválidos.
+- Não localizar o e-mail com o boleto ou as instruções de PIX (verifique o e-mail cadastrado da empresa e a caixa de spam).
+
+## Dicas
+- Confira os limites de cada plano no próprio cartão antes de escolher — o que aparece como "Ilimitado" não tem restrição.
+- Mantenha o e-mail da empresa atualizado em **Configurações** > **Empresa**: é para ele que vão o boleto e as instruções de PIX.

--- a/docs/gestor/conta/como_gerenciar_assinatura.md
+++ b/docs/gestor/conta/como_gerenciar_assinatura.md
@@ -5,8 +5,21 @@ Acesse **Configurações** > **Assinatura**.
 
 ## O que você encontra
 - Status da assinatura (ativa, pendente, cancelada, expirada).
-- Dados do plano atual.
-- Informações de método de pagamento e ciclo (quando disponíveis).
+- Dados do plano atual e valor mensal.
+- Forma de pagamento cadastrada.
+- Limites do plano: técnicos, ordens de serviço e orçamentos ("Ilimitado" quando não há limite).
+- Tipo de suporte incluído no plano.
+
+## Se você está no plano Starter (gratuito)
+- O Starter não tem cobrança: não há valor a pagar nem data de fim de período.
+- Por isso, **não existe botão de cancelar** — não há renovação nem fatura para interromper. Se quiser deixar de usar, basta não acessar o sistema.
+- Os limites são menores (por exemplo, apenas 1 técnico: o próprio gestor atua como técnico) e o suporte é feito somente pela **base de conhecimento**.
+- Nessa mesma tela aparecem os cartões dos **planos pagos disponíveis** para você comparar e fazer upgrade. Veja o guia "Como fazer upgrade de plano".
+
+## Se você está em um plano pago
+- A tela mostra início e fim do período vigente.
+- Na seção **Cancelamento**, você pode solicitar o cancelamento ao fim do período: a assinatura continua ativa até a data informada.
+- Se houver um cancelamento agendado, é possível clicar em **Reativar renovação** para desfazê-lo antes da data efetiva.
 
 ## Dica
 Use essa seção para validar se a empresa está adimplente antes de mudanças operacionais relevantes.

--- a/docs/gestor/conta/como_personalizar_pdf.md
+++ b/docs/gestor/conta/como_personalizar_pdf.md
@@ -1,0 +1,35 @@
+# Como personalizar os PDFs
+
+## Quando usar
+Quando você quer que os PDFs de **Ordem de Serviço** e **Orçamento** saiam com a identidade visual da sua empresa (cores, logo e textos próprios).
+
+## Pré-requisitos
+- Estar no plano **Profissional** ou **Enterprise**. Nos demais planos, a tela exibe o aviso de que a personalização não está disponível.
+
+## Passo a passo
+1. Acesse **Configurações** > **PDF**.
+2. Escolha o bloco que deseja configurar: **Ordem de Serviço** ou **Orçamento** (cada tipo tem configuração independente).
+3. Ative a chave **Personalizar PDF**.
+4. Ajuste as opções:
+   - **Cor principal** do documento.
+   - **Cor do texto** do cabeçalho.
+   - **Logo**: envie uma imagem PNG ou JPG de até 2MB. Se já houver uma logo, você pode clicar em **Remover**.
+   - **Subtítulo** (até 80 caracteres).
+   - **Nota do documento** (até 160 caracteres).
+   - **Rodapé** (até 120 caracteres).
+   - **Seções exibidas**: dados da empresa, dados do cliente, descrição e itens. Na Ordem de Serviço também é possível exibir/ocultar observações e motivo do desconto.
+5. Clique em **Salvar**.
+6. Use **Visualizar PDF** para conferir o resultado antes de enviar aos clientes.
+
+## O que acontece depois
+- Os próximos PDFs gerados daquele tipo de documento saem com a personalização aplicada.
+- Com a chave **Personalizar PDF** desativada, o documento volta ao padrão do sistema.
+
+## Erros comuns
+- Tentar salvar em plano sem acesso ao recurso (disponível apenas nos planos Profissional e Enterprise).
+- Enviar logo em formato não aceito ou acima de 2MB.
+- Tentar **Visualizar PDF** sem ter criado ao menos uma ordem de serviço (ou um orçamento) — a pré-visualização usa um documento real da sua empresa.
+
+## Dicas
+- Configure os dois tipos (Ordem de Serviço e Orçamento) para manter a identidade visual consistente.
+- Mantenha os dados da empresa atualizados em **Configurações** > **Empresa**: eles aparecem nos PDFs.

--- a/docs/gestor/orcamentos/como_cliente_aprova_orcamento.md
+++ b/docs/gestor/orcamentos/como_cliente_aprova_orcamento.md
@@ -1,0 +1,34 @@
+# Como o cliente aprova o orçamento
+
+## Quando usar
+Quando você enviou o orçamento para aprovação e quer entender o que o seu
+cliente vê e faz ao receber o link.
+
+## O que o cliente recebe
+- Um e-mail com o assunto **Aprovação do Orçamento #código** e o link da
+  página de aprovação.
+- O link é exclusivo daquele orçamento e expira na data de validade
+  (prazo de resposta).
+
+## O que o cliente faz na página
+1. Abre o link do e-mail (não precisa de login).
+2. Vê os dados do orçamento: cliente, empresa, título, descrição, prazo de
+   resposta e os itens com quantidade, valor unitário e total.
+3. Pode clicar em **Baixar PDF** para guardar uma cópia.
+4. Para aceitar, clica em **Aprovar** e confirma.
+5. Para recusar, clica em **Rejeitar** e informa o motivo da rejeição
+   (obrigatório).
+
+## O que acontece depois
+- **Aprovar**: o orçamento muda para **Aprovado** e o sistema cria a OS
+  automaticamente com status **Pendente**, copiando os itens do orçamento.
+  Você (gestor) recebe um e-mail avisando que a OS foi criada.
+- **Rejeitar**: o orçamento muda para **Rejeitado** com o motivo informado,
+  e você pode revisá-lo e reenviá-lo.
+- Se o cliente abrir o link de um orçamento já respondido, a página apenas
+  informa que ele já foi aprovado ou rejeitado.
+
+## Erros comuns
+- E-mail do cliente desatualizado no cadastro (o link não chega).
+- Cliente tentar responder após a validade: o link expira e mostra
+  "Link inválido ou expirado" — reenvie o orçamento para gerar um novo link.

--- a/docs/gestor/relatorios/como_exportar_relatorios.md
+++ b/docs/gestor/relatorios/como_exportar_relatorios.md
@@ -1,0 +1,48 @@
+# Como exportar relatórios (CSV)
+
+## Quando usar
+Quando você quer levar os dados dos relatórios para fora do sistema (planilhas, análises externas ou arquivamento).
+
+## Tipos de relatório
+O sistema trabalha com quatro tipos de relatório:
+- **Relatório de Clientes** (categoria Cadastros).
+- **Relatório de Técnicos** (categoria Cadastros).
+- **Ordens de Serviço por Período** (categoria Operacional).
+- **Orçamentos por Período** (categoria Comercial).
+
+Pela tela de **Relatórios**, a exportação gera os tipos **Ordens de Serviço** e **Orçamentos**, conforme a **Base** selecionada nos filtros.
+
+## Passo a passo
+1. Acesse **Relatórios**.
+2. Em **Base**, escolha **Ordens de Serviço** ou **Orçamentos**.
+3. Defina o período em **Data inicial** e **Data final**.
+4. (Opcional) Ajuste **Status** e **Técnico** (apenas para OS).
+5. Clique em **Aplicar** para conferir os dados na tela.
+6. Clique em **Exportar CSV** (também estão disponíveis **Exportar XLSX** e **Exportar PDF**).
+
+## O que acontece depois
+- O sistema exibe a mensagem: "Exportação iniciada. O arquivo aparecerá em 'Relatórios gerados recentemente'."
+- A geração do arquivo acontece **em segundo plano**: você pode continuar usando o sistema normalmente.
+- A exportação passa pelos status: **Pendente** → **Processando** → **Finalizado** (ou **Falhou**, em caso de erro).
+- O card **Relatórios gerados recentemente**, no fim da tela de Relatórios, lista os últimos 5 arquivos gerados com título, tipo, status e data de geração.
+- O arquivo respeita os filtros aplicados no momento da exportação (base, período, agrupamento, status e técnico).
+- O CSV traz os registros detalhados e, ao final, um resumo com os totais do período.
+
+## Como baixar o arquivo
+1. Na tela de **Relatórios**, vá até **Relatórios gerados recentemente**.
+2. Enquanto o arquivo não estiver pronto, a linha mostra **Aguardando**; atualize a página para acompanhar o andamento.
+3. Quando o status estiver **Finalizado**, clique em **Baixar**.
+
+## Regra de período máximo
+- O período máximo permitido para consulta/exportação é de **6 meses**.
+- Se o período selecionado ultrapassar 6 meses, a data inicial é ajustada automaticamente para o limite permitido.
+
+## Erros comuns
+- Esperar o download imediato ao clicar em Exportar: a geração é assíncrona e o arquivo aparece na lista de gerados recentemente.
+- Tentar baixar antes de o status ficar **Finalizado**: o sistema avisa que o arquivo ainda não está disponível para download.
+- Exportar sem conferir os filtros: o arquivo sai com os filtros ativos na tela naquele momento.
+
+## Dicas
+- Aplique os filtros e confira os números na tela antes de exportar.
+- Se a exportação ficar com status **Falhou**, revise o período e os filtros e tente novamente.
+- Prefira CSV/XLSX para trabalhar os dados em planilha; use PDF quando o objetivo for apenas leitura/compartilhamento.

--- a/docs/gestor/suporte/como_abrir_ticket.md
+++ b/docs/gestor/suporte/como_abrir_ticket.md
@@ -3,6 +3,11 @@
 ## Quando usar
 Quando a base de conhecimento não resolver ou houver falha no sistema.
 
+## Disponibilidade por plano
+- No plano **Starter** (gratuito) **não é possível abrir tickets**: o suporte é oferecido somente via **base de conhecimento**.
+- Quem está no Starter e tenta acessar a área de tickets é redirecionado automaticamente para a base de conhecimento, com o aviso "O plano Starter oferece suporte somente via base de conhecimento."
+- Para ter suporte por ticket, é preciso fazer **upgrade** para um plano pago.
+
 ## Passo a passo
 1. Acesse **Suporte** > **Tickets**.
 2. Clique em **Abrir novo ticket**.

--- a/docs/gestor/suporte/como_pedir_ajuda.md
+++ b/docs/gestor/suporte/como_pedir_ajuda.md
@@ -3,6 +3,11 @@
 ## Quando usar
 Use este fluxo quando você tiver um problema que não conseguiu resolver pelos artigos da Central de Ajuda.
 
+## Atenção: plano Starter
+- No plano **Starter** (gratuito), o suporte é oferecido **somente via base de conhecimento**: não é possível abrir tickets nem usar o Contato rápido.
+- Ao tentar acessar essas áreas, você é redirecionado para a base de conhecimento.
+- Para acionar o suporte por ticket, faça **upgrade** para um plano pago.
+
 ## Como pedir ajuda (recomendado)
 Ao acionar o suporte, envie:
 1. **O que você estava tentando fazer**

--- a/docs/gestor/suporte/como_usar_contato_rapido.md
+++ b/docs/gestor/suporte/como_usar_contato_rapido.md
@@ -9,4 +9,8 @@ Quando você precisa de um canal direto e seu plano possui esse recurso.
 3. Use o canal indicado para acionar o time.
 
 ## Observação
-O Contato rápido depende do plano contratado.
+O Contato rápido depende do plano contratado: está disponível apenas nos planos **Profissional** e **Enterprise**.
+
+## Plano Starter
+- Quem está no plano **Starter** (gratuito) **não usa o Contato rápido nem abre tickets**: ao acessar essas áreas, é redirecionado para a **base de conhecimento**.
+- Para ter acesso ao Contato rápido, é preciso fazer **upgrade** para o plano Profissional ou Enterprise.

--- a/docs/operacao/00_indice.md
+++ b/docs/operacao/00_indice.md
@@ -1,0 +1,12 @@
+# CatalystOps — Documentação de Operação
+
+Este guia cobre os procedimentos operacionais do sistema em produção: deploy, monitoramento e conformidade.
+
+## Deploy e Incidentes
+- [Runbook de Deploy/Rollback em Produção](runbook_deploy_rollback_producao.md) — passo a passo de deploy, rollback para imagem/tag anterior, responsáveis e critérios de go/no-go e de rollback em incidente.
+
+## Monitoramento
+- [Monitoramento de Erros (Sentry)](monitoramento_erros_sentry.md) — variáveis de ambiente, comportamento da integração com o Sentry e uso da tela Admin > Métricas.
+
+## Conformidade
+- [LGPD / Termos / Auditoria](lgpd_termos_auditoria.md) — política de retenção de dados de auditoria, trilha de eventos críticos e aceite de termos de utilização.

--- a/docs/tecnico/00_indice.md
+++ b/docs/tecnico/00_indice.md
@@ -5,7 +5,7 @@ Este guia cobre as funcionalidades do perfil **técnico** no ambiente `app`.
 ## Acesso
 - [Como fazer login](acesso/como_fazer_login.md)
 - [Como confirmar cadastro](acesso/como_confirmar_cadastro.md)
-- [Como redefinir senha](acesso/como_redefinir_senha.md)
+- [Esqueci minha senha (redefinir antes do login)](acesso/como_redefinir_senha.md)
 - [Como sair da conta (logout)](acesso/como_sair.md)
 
 ## Visão Geral
@@ -24,6 +24,7 @@ Este guia cobre as funcionalidades do perfil **técnico** no ambiente `app`.
 
 ## Conta
 - [Como atualizar meu perfil](conta/como_atualizar_perfil.md)
+- [Como trocar minha senha (já logado)](conta/como_redefinir_senha.md)
 - [Como aceitar o contrato de utilização](conta/como_aceitar_termos.md)
 
 ## Base de Conhecimento

--- a/docs/tecnico/acesso/como_redefinir_senha.md
+++ b/docs/tecnico/acesso/como_redefinir_senha.md
@@ -1,0 +1,26 @@
+# Esqueci minha senha (redefinir antes do login)
+
+## Quando usar
+Quando você **não consegue entrar** no sistema porque esqueceu a senha. Este fluxo é feito na tela de login, sem estar autenticado.
+
+> Se você já está logado e só quer trocar a senha, veja [Como trocar minha senha](../conta/como_redefinir_senha.md).
+
+## Passo a passo
+1. Acesse `https://login.catalystops.com.br`.
+2. Clique em **Esqueceu sua senha?**.
+3. Na tela **Esqueci minha senha**, informe seu e-mail e clique em **Enviar link de redefinição**.
+4. Abra o e-mail recebido e clique no link de redefinição.
+5. Preencha os campos **Senha** e **Confirmação de senha**.
+6. Clique em **Redefinir senha**.
+
+## Regras da nova senha
+- Mínimo de **8 caracteres**, com **maiúscula, minúscula, número e caractere especial**.
+- Os campos de senha e confirmação devem ser idênticos.
+
+## Resultado
+Você verá a mensagem **"Senha alterada com sucesso! Faça o login."** e será redirecionado para a tela de login, onde já pode entrar com a nova senha.
+
+## Observações
+- Por segurança, a mensagem após o envio é sempre a mesma: *"Se o e-mail existir na base, você receberá o link de redefinição em instantes."* — mesmo que o e-mail digitado não esteja cadastrado.
+- O link de redefinição **expira em 6 horas**. Se expirar, repita o processo para receber um novo link.
+- Se o link for inválido ou expirado, um alerta é exibido; basta solicitar um novo link.

--- a/docs/vendas/documento_de_vendas.md
+++ b/docs/vendas/documento_de_vendas.md
@@ -1,0 +1,161 @@
+# CatalystOps — Documento de Vendas
+
+> Material interno de apoio comercial. Todos os dados de planos, limites e
+> funcionalidades foram extraídos diretamente do sistema em produção
+> (código-fonte e seeds). Última atualização: julho/2026.
+
+## O Que É
+
+CatalystOps é um SaaS de gestão de ordens de serviço para empresas
+prestadoras de serviços técnicos (assistências, manutenção, instalação,
+field service em geral). Centraliza orçamentos, ordens de serviço, agenda de
+técnicos, clientes, financeiro e suporte em um único lugar — com acesso web
+e app mobile para o técnico em campo.
+
+## Público-Alvo
+
+- Assistências técnicas e empresas de manutenção/instalação de pequeno e
+  médio porte.
+- Operações com 1 a dezenas de técnicos em campo.
+- Dono/gestor que hoje controla OS em planilha, papel ou WhatsApp e perde
+  faturamento por falta de organização.
+
+## Proposta de Valor (elevator pitch)
+
+"Do orçamento ao pagamento em um só fluxo: você cria o orçamento, o cliente
+aprova online sem precisar de login, a OS é gerada automaticamente, o técnico
+recebe na agenda e no celular, e o financeiro mostra o que foi realizado e o
+que está pendente."
+
+## Funcionalidades Por Módulo
+
+### Orçamentos com aprovação online (diferencial-chave)
+- Criação de orçamento com itens, valores e prazo de validade.
+- Envio por e-mail com link exclusivo: o cliente final **aprova ou rejeita
+  online, sem login e sem instalar nada**.
+- Aprovação gera a Ordem de Serviço automaticamente, com os itens copiados.
+- PDF do orçamento disponível para o cliente baixar.
+
+### Ordens de Serviço (ciclo completo)
+- Status de ponta a ponta: pendente → agendada → em andamento → concluída →
+  finalizada (com cancelamento e detecção automática de atraso).
+- Itens de serviço (serviços, peças, materiais) com valores.
+- Anexos (fotos, laudos, comprovantes).
+- PDF da OS com envio por e-mail ao cliente.
+- Recibos de entrada e devolução de equipamento do cliente.
+
+### Agenda e técnicos
+- Calendário da operação (dia/semana) e agenda por técnico.
+- Detecção de conflito de horário e aviso de OS simultâneas.
+- Permissões por papel: gestor administra; técnico vê e executa só o que é
+  dele.
+
+### App mobile (API dedicada)
+- Login seguro no celular; o técnico vê dashboard, agenda e suas OS.
+- Atualiza status, adiciona observações e envia fotos direto do atendimento.
+
+### Financeiro e relatórios
+- Visão de faturamento realizado × pendente por itens de OS.
+- Relatórios de OS e orçamentos por período (SLA, tendências, taxa de
+  aprovação, ticket médio).
+- Exportação em CSV, XLSX e PDF, processada em segundo plano.
+
+### Personalização de PDF (planos Profissional e Enterprise)
+- Logo e cores da empresa nos PDFs de OS e orçamento — documento com a marca
+  do cliente, não a nossa.
+
+### Suporte e base de conhecimento
+- Central de ajuda com artigos por perfil (gestor e técnico).
+- Tickets de suporte com acompanhamento.
+- Contato rápido (WhatsApp + e-mail) nos planos Profissional e Enterprise.
+
+### Segurança e conformidade
+- Isolamento total de dados por empresa (multi-tenant).
+- Trilha de auditoria de eventos críticos, com política de retenção (LGPD).
+- Aceite de termos com registro de IP, usuário e data.
+
+## Planos e Preços
+
+Fonte: seeds/configuração de planos do sistema. Limites de OS e orçamentos
+são **mensais** (mês corrente). "Ilimitado" = sem restrição.
+
+| | **Starter** | **Básico** | **Profissional** | **Enterprise** |
+|---|---|---|---|---|
+| **Preço/mês** | R$ 0 | R$ 99 | R$ 199 | R$ 399 |
+| **Técnicos** | 1 (o próprio gestor) | 1 | 6 | Ilimitado |
+| **OS/mês** | 3 | 15 | 60 | 200 |
+| **Orçamentos/mês** | 3 | 15 | 60 | 200 |
+| **Suporte** | Base de conhecimento | E-mail (tickets) | Prioritário + Contato rápido | Dedicado + Contato rápido |
+| **PDF personalizado** | — | — | ✔ | ✔ |
+
+### Regras comerciais do sistema
+- **Starter é gratuito de verdade**: sem cartão, sem cobrança, sem prazo de
+  expiração. Porta de entrada para experimentar o produto.
+- **Upgrade self-service**: quem está no Starter contrata plano pago direto
+  no painel (Configurações > Assinatura), sem falar com ninguém.
+- **Só existe upgrade entre pagos** (Básico → Profissional → Enterprise);
+  não há downgrade pelo painel.
+- **Formas de pagamento**: PIX, boleto e cartão de crédito (Mercado Pago).
+- **Cupons**: desconto (percentual ou valor fixo) ou período de teste
+  (trial). Um cupom por empresa a cada 12 meses. Cupom de desconto não se
+  aplica a cadastro com cartão de crédito.
+- Cancelamento de plano pago é agendado para o fim do período já pago, com
+  opção de reativar antes de efetivar.
+
+## Argumentos de Venda Por Persona
+
+### Dono/gestor sobrecarregado
+- "Quantas OS você perdeu esse mês por esquecer de agendar ou cobrar?"
+- Dashboard com visão do dia, OS atrasadas destacadas automaticamente,
+  faturamento pendente visível.
+
+### Operação em crescimento (contratando técnicos)
+- Agenda por técnico com detecção de conflito.
+- Permissões prontas: técnico não vê financeiro nem dados de outros
+  atendimentos.
+- App mobile: técnico novo produz no primeiro dia.
+
+### Empresa que quer profissionalizar a imagem
+- Cliente final aprova orçamento em página profissional, sem login.
+- PDF com logo e cores da empresa (Profissional/Enterprise).
+- Recibos de entrada/devolução de equipamento.
+
+## Objeções Comuns e Respostas
+
+| Objeção | Resposta |
+|---|---|
+| "É caro." | Comece no Starter gratuito — 3 OS/mês sem pagar nada. O Básico custa R$ 99: uma OS recuperada por mês já paga o sistema. |
+| "Meu técnico não vai usar." | O app mobile mostra só o que ele precisa: agenda e OS dele. Atualizar status e mandar foto é mais fácil que responder WhatsApp. |
+| "Já uso planilha." | Planilha não avisa OS atrasada, não deixa o cliente aprovar orçamento online e não gera OS sozinha. |
+| "E se eu quiser sair?" | Sem fidelidade: o cancelamento vale até o fim do período pago e os relatórios exportam seus dados em CSV/XLSX. |
+| "Meus dados ficam seguros?" | Isolamento por empresa, auditoria de eventos críticos e conformidade LGPD (retenção e aceite de termos registrados). |
+
+## Jornada do Cliente (funil)
+
+1. **Cadastro gratuito** no Starter (sem cartão) → onboarding guiado com
+   checklist de primeiros passos.
+2. **Ativação**: cria cliente, orçamento e primeira OS (o checklist conduz).
+3. **Limite como gatilho**: ao bater 3 OS/orçamentos no mês, o sistema
+   oferece upgrade no próprio painel.
+4. **Conversão self-service**: escolhe plano, paga com PIX/boleto/cartão,
+   acesso liberado na confirmação.
+5. **Expansão**: crescimento de equipe leva Básico → Profissional →
+   Enterprise (limite de técnicos é o principal gatilho).
+
+## O Que NÃO Prometer (limites reais do produto hoje)
+
+- Não há downgrade de plano pelo painel.
+- Não há exportação de cadastro de clientes/técnicos pela tela de
+  relatórios (somente OS e orçamentos).
+- Contato rápido (WhatsApp) só existe em Profissional e Enterprise.
+- Starter não abre ticket de suporte (só base de conhecimento).
+- Sem integração com outros gateways além do Mercado Pago.
+- Sem app publicado em loja — o mobile é via API/app próprio (confirmar
+  status de publicação antes de prometer).
+
+## Documentos Relacionados
+
+- Matriz técnica de planos e assinaturas: `docs/dev/ai/assinaturas.md`
+- Upgrade pelo painel: `docs/gestor/conta/como_fazer_upgrade_de_plano.md`
+- Aprovação de orçamento pelo cliente: `docs/gestor/orcamentos/como_cliente_aprova_orcamento.md`
+- Personalização de PDF: `docs/gestor/conta/como_personalizar_pdf.md`

--- a/docs/vendas/documento_de_vendas.md
+++ b/docs/vendas/documento_de_vendas.md
@@ -9,8 +9,8 @@
 CatalystOps é um SaaS de gestão de ordens de serviço para empresas
 prestadoras de serviços técnicos (assistências, manutenção, instalação,
 field service em geral). Centraliza orçamentos, ordens de serviço, agenda de
-técnicos, clientes, financeiro e suporte em um único lugar — com acesso web
-e app mobile para o técnico em campo.
+técnicos, clientes, financeiro e suporte em um único lugar, acessível pelo
+navegador em qualquer dispositivo.
 
 ## Público-Alvo
 
@@ -24,8 +24,8 @@ e app mobile para o técnico em campo.
 
 "Do orçamento ao pagamento em um só fluxo: você cria o orçamento, o cliente
 aprova online sem precisar de login, a OS é gerada automaticamente, o técnico
-recebe na agenda e no celular, e o financeiro mostra o que foi realizado e o
-que está pendente."
+recebe na agenda dele, e o financeiro mostra o que foi realizado e o que está
+pendente."
 
 ## Funcionalidades Por Módulo
 
@@ -48,11 +48,8 @@ que está pendente."
 - Calendário da operação (dia/semana) e agenda por técnico.
 - Detecção de conflito de horário e aviso de OS simultâneas.
 - Permissões por papel: gestor administra; técnico vê e executa só o que é
-  dele.
-
-### App mobile (API dedicada)
-- Login seguro no celular; o técnico vê dashboard, agenda e suas OS.
-- Atualiza status, adiciona observações e envia fotos direto do atendimento.
+  dele — dashboard, agenda e OS próprias, acessíveis também pelo navegador
+  do celular.
 
 ### Financeiro e relatórios
 - Visão de faturamento realizado × pendente por itens de OS.
@@ -113,7 +110,7 @@ são **mensais** (mês corrente). "Ilimitado" = sem restrição.
 - Agenda por técnico com detecção de conflito.
 - Permissões prontas: técnico não vê financeiro nem dados de outros
   atendimentos.
-- App mobile: técnico novo produz no primeiro dia.
+- Interface simples para o técnico: técnico novo produz no primeiro dia.
 
 ### Empresa que quer profissionalizar a imagem
 - Cliente final aprova orçamento em página profissional, sem login.
@@ -125,7 +122,7 @@ são **mensais** (mês corrente). "Ilimitado" = sem restrição.
 | Objeção | Resposta |
 |---|---|
 | "É caro." | Comece no Starter gratuito — 3 OS/mês sem pagar nada. O Básico custa R$ 99: uma OS recuperada por mês já paga o sistema. |
-| "Meu técnico não vai usar." | O app mobile mostra só o que ele precisa: agenda e OS dele. Atualizar status e mandar foto é mais fácil que responder WhatsApp. |
+| "Meu técnico não vai usar." | O técnico vê só o que precisa: agenda e OS dele, direto no navegador do celular. Atualizar status e anexar foto é mais fácil que responder WhatsApp. |
 | "Já uso planilha." | Planilha não avisa OS atrasada, não deixa o cliente aprovar orçamento online e não gera OS sozinha. |
 | "E se eu quiser sair?" | Sem fidelidade: o cancelamento vale até o fim do período pago e os relatórios exportam seus dados em CSV/XLSX. |
 | "Meus dados ficam seguros?" | Isolamento por empresa, auditoria de eventos críticos e conformidade LGPD (retenção e aceite de termos registrados). |
@@ -150,8 +147,16 @@ são **mensais** (mês corrente). "Ilimitado" = sem restrição.
 - Contato rápido (WhatsApp) só existe em Profissional e Enterprise.
 - Starter não abre ticket de suporte (só base de conhecimento).
 - Sem integração com outros gateways além do Mercado Pago.
-- Sem app publicado em loja — o mobile é via API/app próprio (confirmar
-  status de publicação antes de prometer).
+- **App mobile ainda não foi entregue** — a infraestrutura (API) existe, mas
+  o aplicativo será lançado depois. Não prometer app em loja nem citar prazo
+  sem alinhamento com produto. Enquanto isso, o acesso do técnico é pelo
+  navegador do celular.
+
+## Roadmap (usar com cautela na venda)
+
+- **App mobile do técnico**: em desenvolvimento, será entregue em fase
+  posterior. Pode ser mencionado como visão de futuro, nunca como
+  funcionalidade atual ou com data.
 
 ## Documentos Relacionados
 


### PR DESCRIPTION
## Resumo

Auditoria completa da documentação contra a superfície real do código, preenchimento das lacunas encontradas e criação do documento de vendas.

### 📚 Lacunas de documentação preenchidas

**Novos docs técnicos (`docs/dev/ai/`)**
- `api_mobile.md` — API mobile (auth por token Bearer, dashboard, agenda, OS, orçamentos)
- `admin_backoffice.md` — área administrativa completa (15 seções)
- `onboarding.md` — checklist de progresso, modal de boas-vindas, métricas de ativação/D7
- `portal_cliente.md` — portal público de aprovação de orçamento por token

**Docs atualizados com o plano Starter**
- `docs/dev/ai/assinaturas.md` — plano gratuito, `end_date` nulo, upgrade self-service, limites por plano, cupons
- `docs/gestor/conta/como_gerenciar_assinatura.md`
- 3 docs de suporte do gestor (Starter não abre ticket; redirecionamento à base de conhecimento)

**Novos docs de central de ajuda (gestor)**
- Como fazer upgrade de plano
- Como personalizar o PDF de OS e orçamentos (Profissional/Enterprise)
- Como exportar relatórios (CSV/XLSX/PDF)
- Como o cliente aprova o orçamento (portal do cliente)

**Correções**
- Link quebrado em `docs/tecnico/00_indice.md` + criação do doc "esqueci minha senha" do técnico
- Criação de `docs/operacao/00_indice.md`
- Índices (`dev/ai`, `gestor`) e mapa de contexto do `AGENTS.md` atualizados — todos os links validados

### 📄 Documento de vendas (`docs/vendas/documento_de_vendas.md`)

Material interno de apoio comercial, com todos os dados verificados no código/seeds: pitch, funcionalidades por módulo, matriz de planos e preços, regras comerciais (upgrade, cupons, pagamento), argumentos por persona, objeções com respostas e seção "o que não prometer".

### ⚠️ Débitos técnicos descobertos (não corrigidos neste PR)

1. Rota órfã `resources :contents` em `config/routes/admin.rb:34` sem controller correspondente
2. Tipos `clients`/`technicians` existem no enum de `Report` mas sem fluxo de exportação ligado
3. Não existem specs para a API mobile
4. No mobile, gestor só vê OS às quais está atribuído (escopo `by_technician` para qualquer papel) — verificar se é intencional

🤖 Generated with [Claude Code](https://claude.com/claude-code)