### PR TITLE
Ativa empresa e usuários no cadastro do plano Starter

### DIFF
--- a/app/controllers/register/signups_controller.rb
+++ b/app/controllers/register/signups_controller.rb
@@ -50,6 +50,7 @@ class Register::SignupsController < ApplicationController
     end
 
     if @company.plan&.free?
+      @company.activate!
       @user.send_starter_welcome_email!
       return redirect_to success_path(company_id: @company.id, starter: "1")
     elsif trial_coupon_without_mercado_pago?(coupon_result)


### PR DESCRIPTION
## Problema

No fluxo de signup ([`Register::SignupsController#create`](app/controllers/register/signups_controller.rb)), empresa e usuários são criados com `active: false`. A ativação normalmente acontece via o callback `sync_company_access` da `Subscription`:

```ruby
after_commit :sync_company_access, on: :update, if: -> { previous_changes.key?('status') }
```

Esse callback roda **apenas `on: :update`**, quando o `status` muda (ex.: webhook de pagamento confirmado nos planos pagos → `company.activate!`).

No **plano Starter (gratuito)**, porém, a subscription já é **criada** (INSERT) com `status: :active` — não é um update. Resultado:

- O callback `sync_company_access` **nunca dispara**.
- Empresa e usuário permanecem `active: false`.
- O e-mail de Starter manda um **link de login**, mas o login exige `active?` (`SessionsController#create`), então o gestor recebe *"E-mail ou senha inválidos"* mesmo após o e-mail dizer que "o plano está ativo".

Ou seja: o cliente Starter ficava preso, sem conseguir logar após o cadastro.

## Correção

Chama `@company.activate!` no ramo do plano free, antes de enviar o e-mail de boas-vindas. O `activate!` marca a empresa e **todos os seus usuários** como `active: true` ([`Company#activate!`](app/models/company.rb#L122-L125)).

```ruby
if @company.plan&.free?
  @company.activate!
  @user.send_starter_welcome_email!
  return redirect_to success_path(company_id: @company.id, starter: "1")
```

Fluxos de planos pagos não são afetados — continuam ativando via webhook de pagamento.

## Como testar

1. Fazer um cadastro selecionando o plano Starter.
2. Confirmar no log que a empresa/usuário ficam `active: true`.
3. Confirmar que o login funciona logo após o cadastro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)